### PR TITLE
fix(ci): handle large PRs and improve TSDoc sync workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,19 +46,25 @@ jobs:
         run: |
           bun install
 
-      - name: Check for API or Skills changes
+      - name: Check for TypeScript or Skills changes
         id: check-changes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get list of changed files
-          CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          # Get list of changed files using gh pr view (handles large PRs better than gh pr diff)
+          CHANGED_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
 
-          # Check for API changes (src/*/index.ts exports, public APIs)
-          if echo "$CHANGED_FILES" | grep -qE '^src/.*/index\.ts$|^src/[^/]+\.ts$'; then
-            echo "api_changed=true" >> $GITHUB_OUTPUT
+          # Check for TypeScript changes (any .ts or .tsx file)
+          TS_FILES=$(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx)$' || true)
+          if [ -n "$TS_FILES" ]; then
+            echo "typescript_changed=true" >> $GITHUB_OUTPUT
+            # Store the list of changed TypeScript files (newline-separated)
+            echo "typescript_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$TS_FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
           else
-            echo "api_changed=false" >> $GITHUB_OUTPUT
+            echo "typescript_changed=false" >> $GITHUB_OUTPUT
+            echo "typescript_files=" >> $GITHUB_OUTPUT
           fi
 
           # Check for skills changes
@@ -94,7 +100,9 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
-            API_CHANGED: ${{ steps.check-changes.outputs.api_changed }}
+            TYPESCRIPT_CHANGED: ${{ steps.check-changes.outputs.typescript_changed }}
+            TYPESCRIPT_FILES: |
+              ${{ steps.check-changes.outputs.typescript_files }}
             SKILLS_CHANGED: ${{ steps.check-changes.outputs.skills_changed }}
 
             ## Task 1: Review Pull Request
@@ -118,23 +126,22 @@ jobs:
                - Any breaking changes
                - Testing notes
 
-            2. **Leave approval comment**: Use `gh pr comment` with your review summary.
-
-            ## Task 3: Documentation Sync (if API_CHANGED=true or SKILLS_CHANGED=true)
-
-            If API or skills files changed:
-
-            1. **Check affected files** for missing or outdated TSDoc comments
-            2. **Update documentation** using the code-documentation@plaited_development-skills skill patterns:
+            2. **TSDoc Sync** (only if TYPESCRIPT_CHANGED=true):
+               After approving, check ALL files listed in TYPESCRIPT_FILES for missing or outdated TSDoc comments.
+               These are ALL TypeScript files changed in this PR (across all commits):
+               - Read each file in TYPESCRIPT_FILES
                - Add missing TSDoc for new public exports
                - Update existing TSDoc if signatures changed
                - Use `@internal` for non-public APIs
-            3. **Commit changes** to this PR branch with message:
-               ```
-               docs: sync API documentation
+               - Use the code-documentation@plaited_development-skills skill patterns
+               - Commit ALL TSDoc changes together with message:
+                 ```
+                 docs: sync TSDoc comments
 
-               Co-Authored-By: Claude <noreply@anthropic.com>
-               ```
+                 Co-Authored-By: Claude <noreply@anthropic.com>
+                 ```
+
+            3. **Leave approval comment**: Use `gh pr comment` with your review summary.
 
             Be constructive and helpful in your feedback.
 


### PR DESCRIPTION
## Summary

- Fix HTTP 406 error on large PRs by replacing `gh pr diff` with `gh pr view --json files`
- Detect all TypeScript files (`*.ts`, `*.tsx`) instead of only `index.ts` files
- Pass explicit file list to Claude for consistent TSDoc updates across all commits
- Integrate TSDoc sync into approval flow for clearer sequencing

## What Changed

- **API Call**: `gh pr diff --name-only` → `gh pr view --json files --jq '.files[].path'`
  - Fixes HTTP 406 errors on PRs exceeding ~20,000 lines of diff
  - More reliable for large PRs
- **Detection Logic**: `api_changed` (only index.ts) → `typescript_changed` (all TS/TSX files)
  - More comprehensive coverage for TSDoc sync
  - Better variable naming
- **File List**: Added `typescript_files` output variable
  - Passes explicit list of changed TypeScript files to Claude
  - Enables thorough TSDoc review across all commits
- **Workflow Structure**: Moved TSDoc sync from Task 3 into Task 2 (On Approval)
  - Clearer sequencing: review → approve → sync docs → comment
  - Reduces task fragmentation

## Why These Changes

1. **Large PR Support**: The previous `gh pr diff` command fails with HTTP 406 on large PRs, blocking automated reviews. Using `gh pr view --json` works regardless of PR size.

2. **Complete TSDoc Coverage**: Only checking `index.ts` files missed documentation updates needed in implementation files. Checking all TypeScript files ensures comprehensive coverage.

3. **Consistency**: Passing the explicit file list ensures Claude reviews the same files across all invocations, preventing missed documentation.

4. **Better UX**: Integrating TSDoc sync into the approval flow makes the process more intuitive and sequential.

## Breaking Changes

None. This is a workflow improvement with no API or behavioral changes to the codebase.

## Testing Notes

- Tested with small PRs to verify TypeScript detection works
- Verified `gh pr view --json files` returns correct file paths
- Confirmed shell script handles empty file lists correctly
- Large PR testing should be done on next sizable PR (>20k line diff)

🤖 Generated with [Claude Code](https://claude.com/code)