### PR TITLE
docs: gap analysis, critique response, and architecture decisions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "agent-skills-spec": {
+      "type": "http",
+      "url": "https://agentskills.io/mcp"
+    },
+    "model-context-protocol-docs":{
+      "type": "http",
+      "url": "https://modelcontextprotocol.io/mcp"
+    },
+    "bun-docs" : {
+      "type": "http",
+      "url": "https://bun.com/docs/mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,10 +195,6 @@ graph TD
 **Coverage checklist** - Happy path, edge cases, error paths, real integrations  
 *Verify:* Review test file completeness
 
-**Docker tests** - `*.docker.ts` for external APIs, run via docker-compose  
-*Verify:* Check if test needs API key or external service  
-*Fix:* Rename to `.docker.ts`, update CI gating
-
 **Run:** `bun test` before commit
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,8 @@ Building top-down: UI → WebSocket server → agent loop. The full stack (agent
 - `docs/HYPERGRAPH-MEMORY.md` — git-versioned JSON-LD memory, context assembly, plans as bThreads
 - `docs/TRAINING.md` — distillation pipeline, training tiers, flywheel
 - `docs/PROJECT-ISOLATION.md` — multi-project orchestrator, IPC bridge, tool layers
-- `docs/MODNET-IMPLEMENTATION.md` — modnet topology, A2A protocol, identity, access control, payment, module sidecar
+- `docs/MODNET-IMPLEMENTATION.md` — modnet topology, A2A protocol, identity, access control, payment, module registry
+- `docs/CRITIQUE-RESPONSE.md` — gap resolutions, attestation layer, module architecture evolution
 - `docs/GENOME.md` — genome architecture for skills (seeds/tools/eval split, CONTRACT frontmatter, wave ordering)
 - `docs/UI.md` — current `src/ui/` architecture (rendering, protocol, custom elements)
 - `docs/WEBSOCKET-ARCHITECTURE.md` — open design questions for the WebSocket server layer
@@ -326,6 +327,7 @@ Building top-down: UI → WebSocket server → agent loop. The full stack (agent
 - `src/server/` — thin I/O server via `createServer()` (routes, WebSocket, pub/sub, hot reload). Auth routes return 501 stubs.
 - `src/agent/` — production types (`agent.types.ts`, `agent.schemas.ts`, `agent.constants.ts`, `agent.utils.ts`)
 - `src/tools/` — `crud/` handlers, `trial.*`, `validate-skill.ts`, `lsp.ts`, `cli.utils.ts`, `tools.registry.ts`, `hypergraph.schemas.ts`
+- `src/a2a/` — (planned) Bun-native A2A protocol implementation: data model, abstract operations, protocol bindings (HTTP+JSON, WebSocket, unix socket)
 
 **What's next:** WebAuthn auth → agent loop (`createAgentLoop()`) → governance factories.
 
@@ -361,6 +363,14 @@ Key implementation decisions. See `docs/ARCHITECTURE.md`, `docs/SAFETY.md`, `doc
 **Risk tags:** Implemented in `agent.constants.ts`. Tags: `workspace`, `crosses_boundary`, `inbound`, `outbound`, `irreversible`, `external_audience`. Empty/unknown → simulate+judge; workspace-only → execute directly; boundary/irreversible/audience → simulate+judge.
 
 **Bash sandboxing:** Bun Shell (`Bun.$`) — `$.cwd()`, `$.env()`, auto-escaping, `$.nothrow()`. Constitution bThreads block dangerous patterns via `execute` event predicates.
+
+**Runtime hierarchy:** `Bun.spawn() → behavioral() → bThread → bSync`. Four levels with distinct isolation/cost. PM's `behavioral()` engine is the central coordinator. Sub-agents run as `Bun.spawn()` processes (stable termination, crash isolation). Workers deferred (experimental `terminate()`). IPC uses `serialization: "advanced"` (JSC structured clone). `SubAgentHandle` interface (uses `Trigger` type — same as BP) abstracts transport.
+
+**Local inference:** Inference server runs as persistent `Bun.spawn()` process on same box (Ollama, llama.cpp, vLLM). Sub-agents call via `fetch("http://localhost:PORT")` — async I/O. GPU/Apple Silicon Metal handles acceleration.
+
+**Module registry:** SKILL.md `metadata` replaces `.meta.db` sidecar and `.workspace.db`. PM reads frontmatter for module discovery, cross-module queries, dependency resolution. No `collect_metadata` tool needed.
+
+**A2A transport:** Bun-native implementation in `src/a2a/` — no a2a-js dependency. One `Bun.serve()` handles HTTP+JSON/REST, WebSocket (custom binding per A2A spec §12), and unix sockets. mTLS via `MutualTlsSecurityScheme`. Unix sockets for same-box (k8s pods, docker-compose). WebSocket for persistent cross-network PM collaboration. See `MODNET-IMPLEMENTATION.md` § A2A Transport Strategy.
 
 **Training weights:** Training weight = `outcome × process`. BP snapshots (`DecisionStep` in `TrajectoryStep`) provide deterministic process signal without a learned PRM. `GradingDimensions` separates outcome, process, and efficiency scoring. `withMetaVerification` wraps graders with confidence scoring. Augmented self-distillation: bootstrap (shadowing) → refinement (self-vs-self) → probing (adversarial). See `docs/TRAINING.md`.
 
@@ -465,6 +475,7 @@ src/tools/
 
 - [ ] WebAuthn auth (passkey registration/verification via SimpleWebAuthn)
 - [ ] `src/agent/` — agent loop implementation (`createAgentLoop()`)
+- [ ] `src/a2a/` — Bun-native A2A protocol (data model, operations, HTTP+JSON/WebSocket/unix bindings, mTLS)
 - [ ] Phase 2–3 — Governance factories + pipeline handlers
 - [ ] Phase 4 — Default tool skills + evals
 - [ ] Genome skills restructuring (seeds/tools/eval directories)

--- a/docs/AGENT-LOOP.md
+++ b/docs/AGENT-LOOP.md
@@ -4,7 +4,9 @@
 
 ## The 6-Step Loop
 
-One central `behavioral()` program orchestrates the entire loop. No actors, no workers, no separate signal stores. BP manages state through bThread closures and coordinates compute via `Bun.spawn()` subprocesses for inference and sandboxed execution.
+The PM's `behavioral()` engine is the central coordinator. Sub-agents run as `Bun.spawn()` processes for crash isolation, each with their own inference context. The PM's bThreads handle all structural coordination — task lifecycle, batch completion, constitution enforcement, simulation guards. Sub-agents have minimal bThreads scoped to their role (or none — simple inference runners).
+
+See `ARCHITECTURE.md` § Runtime Hierarchy for the full `Bun.spawn → behavioral → bThread → bSync` isolation model.
 
 ```mermaid
 graph LR
@@ -89,6 +91,54 @@ graph TD
 **Narrow World View:** Each tool call is an independent scenario. `model_response` triggers one `context_ready` event per tool call, each flowing through its own pipeline. `batchCompletion` waits for all N to resolve, then triggers `context_assembly` for the next inference call.
 
 **Pipeline pass-through:** Events always flow through the full simulate → evaluate → execute pipeline. When a seam is absent, the handler passes through via optional chaining — no conditional routing.
+
+## Sub-Agent Coordination (4-Step Harness)
+
+The PM decomposes complex tasks into sub-tasks, each handled by a `Bun.spawn()` sub-agent. The harness maps to BP:
+
+1. **Decompose** — PM reads task context, breaks into sub-tasks via bThread coordination
+2. **Parallelize** — Spawn sub-agent processes (each calls local inference server via `fetch`)
+3. **Verify** — Judge sub-agent evaluates results against acceptance criteria
+4. **Iterate** — On failure, spawn FRESH sub-agent with error context (new process, clean context window)
+
+```mermaid
+graph TD
+    subgraph PM["PM Engine (persistent behavioral())"]
+        TASK["task event"]
+        DECOMP["Decompose<br/>bThread breaks into sub-tasks"]
+        BATCH["batchCompletion<br/>waits for N results"]
+        CONST["Constitution<br/>MAC/DAC bThreads"]
+    end
+
+    subgraph Workers["Sub-Agents (Bun.spawn, ephemeral)"]
+        W1["Worker 1<br/>fetch → inference server"]
+        W2["Worker 2<br/>fetch → inference server"]
+        JUDGE["Judge<br/>evaluates against criteria"]
+    end
+
+    subgraph Infra["Infrastructure (Bun.spawn, persistent)"]
+        INF["Inference Server<br/>Ollama / llama.cpp / vLLM"]
+    end
+
+    TASK --> DECOMP
+    DECOMP -->|"spawn"| W1
+    DECOMP -->|"spawn"| W2
+    W1 -->|"IPC result"| BATCH
+    W2 -->|"IPC result"| BATCH
+    BATCH -->|"spawn"| JUDGE
+    JUDGE -->|"IPC verdict"| PM
+    W1 -.->|"fetch localhost"| INF
+    W2 -.->|"fetch localhost"| INF
+    JUDGE -.->|"fetch localhost"| INF
+    CONST -.->|"blocks"| DECOMP
+
+    style W1 fill:#e8d5f5,stroke:#333
+    style W2 fill:#e8d5f5,stroke:#333
+    style JUDGE fill:#e8d5f5,stroke:#333
+    style INF fill:#d5e8f5,stroke:#333
+```
+
+Sub-agents communicate with the PM via the `SubAgentHandle` interface (see `ARCHITECTURE.md` § Runtime Hierarchy). IPC uses `serialization: "advanced"` (JSC structured clone). The inference server is a persistent process on the same box — sub-agents call it via `fetch("http://localhost:PORT")`, making inference async I/O from the sub-agent's perspective.
 
 ## ACP Interface (Agent Communication Protocol)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,19 +30,23 @@ The framework is **not prescriptive** about inference backend. Consumers choose 
 The Model and Indexer are interfaces, not implementations:
 
 ```typescript
-type ModelResponse = {
-  thinking: string    // from <think>...</think> — observability + training signal
-  toolCall: ToolCall  // structured tool call from post-</think> response
-}
+type ModelDelta =
+  | { type: 'thinking_delta'; content: string }
+  | { type: 'text_delta'; content: string }
+  | { type: 'toolcall_delta'; toolCall: Partial<ToolCall> }
+  | { type: 'done'; usage: { inputTokens: number; outputTokens: number } }
+  | { type: 'error'; error: Error }
 
 type Model = {
-  reason(context: ModelContext): Promise<ModelResponse>
+  reason(context: ModelContext, signal?: AbortSignal): AsyncIterable<ModelDelta>
 }
 
 type Indexer = {
   embed(text: string): Promise<Float32Array>
 }
 ```
+
+The `AsyncIterable<ModelDelta>` interface works identically whether the backend is a local inference server (Ollama on localhost), a cloud GPU (vLLM), or an API endpoint (OpenRouter). Deltas stream via BP events (`thinking_delta`, `text_delta`) for progressive UI rendering. OpenAI-compatible wire format.
 
 ### Reference Model Stack
 
@@ -58,10 +62,46 @@ type Indexer = {
 - **Framework, Not Platform:** Composable primitives. Code via npm, models via Hugging Face. Platforms are built with it, not by it.
 - **Single Tenancy:** 1 User : 1 Agent instance. User data lives on their agent — nowhere else.
 - **Pluggable Models:** Model and Indexer are interfaces. Implementations swap freely.
-- **BP-Orchestrated:** One central `behavioral()` program coordinates the entire agent loop. No actors, no workers, no external signal stores.
+- **BP-Orchestrated:** The PM's `behavioral()` engine is the central coordinator. Sub-agents run as `Bun.spawn()` processes for crash isolation; the PM's bThreads handle all structural coordination (task lifecycle, batch completion, constitution enforcement). See Runtime Hierarchy below.
 - **Plan-Driven Context:** The model's plan provides the optimization signal for context assembly. Neural produces, symbolic consumes.
 - **Defense in Depth:** Six independent safety layers across three stack levels. See `SAFETY.md`.
 - **Three-Axis Risk Awareness:** Capability × Autonomy × Authority. Risk grows geometrically when all three scale. BP constraints cap each axis independently.
+
+## Runtime Hierarchy
+
+Four native levels of coordination, each with distinct isolation, cost, and guarantees:
+
+```
+Bun.spawn()      — OS process isolation (~ms create, structured clone IPC)
+  behavioral()   — logical isolation, separate event space (~μs, function call)
+    bThread      — shared event space, formal blocking (~μs, O(n) selection)
+      bSync      — atomic synchronization point (~ns, array index)
+```
+
+Each level down is orders of magnitude cheaper but trades isolation for speed. The design principle: **push coordination DOWN the stack as far as isolation allows.**
+
+| Level | Isolation | Message Cost | Use For |
+|---|---|---|---|
+| `Bun.spawn()` | Full (separate V8 heap) | ~μs (JSC structured clone) | Inference server (persistent), sub-agents (ephemeral), sandboxed bash |
+| `behavioral()` | Logical (separate event space) | ~ns (function call) | PM engine + UI controller (same process, zero-copy via `useRestrictedTrigger`) |
+| `bThread` | None (shared event space) | Event selection eval | Constitution rules, task lifecycle, batch coordination |
+| `bSync` | None (sequential) | Array advance | Individual synchronization points |
+
+**Sub-agents** are `Bun.spawn()` processes, not bThreads. They have their own inference context and optionally their own `behavioral()` engine scoped to their role. The PM coordinates against a `SubAgentHandle` interface:
+
+```typescript
+type SubAgentHandle = {
+  send: Trigger                     // PM → sub-agent (same Trigger type as BP)
+  onMessage(handler: Trigger): void // sub-agent → PM
+  terminate(): Promise<void>
+}
+```
+
+**Why `Bun.spawn()` over Workers:** Sub-agents are ephemeral — spawn, do work, terminate. Bun's Worker API is experimental (particularly `worker.terminate()`). `Bun.spawn()` has OS-guaranteed process lifecycle (SIGTERM/SIGKILL/exit codes). IPC defaults to `serialization: "advanced"` (JSC structured clone — not JSON). When Workers stabilize, swapping is a one-interface change.
+
+**Local inference:** The inference server runs as a persistent `Bun.spawn()` process (Ollama, llama.cpp, vLLM) on the same box. Sub-agents call it via `fetch("http://localhost:PORT")` — async I/O that doesn't block the event loop. GPU/Apple Silicon Metal handles acceleration.
+
+**A2A transport:** Bun-native implementation of A2A protocol (no a2a-js dependency). One `Bun.serve()` handles all transports — HTTP+JSON/REST, WebSocket (custom binding), and unix sockets — with native mTLS. See `MODNET-IMPLEMENTATION.md` § A2A Transport Strategy for deployment-specific bindings. Implementation in `src/a2a/`.
 
 ## Deployment Tiers
 
@@ -89,6 +129,7 @@ The pluggable model interfaces make tier selection a deployment decision, not an
 | `PROJECT-ISOLATION.md` | Multi-project orchestrator, IPC bridge, tool layers |
 | `MODNET-IMPLEMENTATION.md` | Modnet topology, A2A protocol, identity, access control, payment |
 | `GENOME.md` | Skills taxonomy (seeds/tools/eval), CONTRACT frontmatter, wave ordering |
+| `CRITIQUE-RESPONSE.md` | Gap resolutions, attestation layer, module architecture evolution |
 | `UI.md` | Generative UI rendering pipeline, controller protocol |
 | `WEBSOCKET-ARCHITECTURE.md` | WebSocket server layer design |
 | `BEHAVIORAL-PROGRAMMING.md` | BP paradigm foundation |

--- a/docs/CRITIQUE-RESPONSE.md
+++ b/docs/CRITIQUE-RESPONSE.md
@@ -1,0 +1,488 @@
+# Response: System-State Steering in a Modnet Architecture
+
+> **Status: ACTIVE** — Response to [external critique](https://gist.github.com/yshaaban/51f31203be945887df69892e850d5bd7) of [`correct-behavior-analysis.md`](https://gist.github.com/yshaaban/5b90cc2dcd505babcfe3505f1b5fbb74). Resolves all 7 gaps through existing design, modnet alignment, and targeted extensions. Module architecture evolution (C+D combined, AgentSkills alignment, mechanics-driven dynamics) further strengthens resolutions.
+>
+> *Documents referenced below (e.g., `SAFETY.md`, `CONSTITUTION.md`, `MODNET-IMPLEMENTATION.md`) are internal architecture specifications within the project repository.*
+
+## Summary
+
+The critique argues that steering enterprise agents is a **control-plane problem over system state**, not just trajectory evaluation. It identifies seven gaps in the original analysis. This response resolves all seven — three through existing design that was insufficiently surfaced, three through new features that compose with existing primitives, and one through extending an existing capability to cover additional deployment contexts.
+
+| Gap | Resolution | Category |
+|---|---|---|
+| 1: Post-execution verification | **New feature**: attestation layer + commit-as-hyperedge + git hooks | Extension |
+| 2: System state model | **Existing**: modnet module graph + bridge-code + hypergraph | Reframe |
+| 3: Evidence-backed meta-verification | **New feature**: evidence vertices with `attestsTo` + `artifacts` | Extension |
+| 4: Resource-action-condition authority | **Existing**: ABAC already designed, scope extension needed | Reframe |
+| 5: Data governance | **Existing**: MSS bridge-code IS data governance | Reframe |
+| 6: Composite process signal | **New feature**: evidence vertices as additional signal sources | Extension |
+| 7: Control-plane integration | **Existing + extension**: distributed control plane via BP + A2A + hosted infrastructure | Reframe |
+
+## What the Critique Validates
+
+Two areas where the architecture directly addresses the critique's concerns — and the critique confirms this:
+
+**Hard constraints outside reward.** The critique says: "hard constraints belong outside the reward function. If an action violates policy or exceeds delegated authority, the system should reject it outright rather than merely assigning it a lower score." This is exactly what BP block predicates do. The neuro-symbolic split in `CONSTITUTION.md` — structural rules reject outright via bThread blocks, reward shapes behavior among allowed actions via training — matches this prescription precisely.
+
+**Deterministic process ground truth.** The critique says BP snapshots are "real ground truth" and "valuable." It positions them as "one verifier among several" — which is fair and addressed below (Gap 6). But the core value of deterministic process signals from the BP engine is validated.
+
+## What the Critique Assumes
+
+The critique operates from a centralized enterprise context: a platform with CI/CD pipelines, deployment approval workflows, shared infrastructure, and a unified control plane. This is a valid deployment scenario — and one the architecture supports — but it's not the only one, and it's not the architecture's starting point.
+
+The architecture is built on **modnet** principles — a module network design where:
+
+- **1 node : 1 user** — each agent is a sovereign node, controlling its own modules and data
+- **Modules are internal** — code and data live inside the node; only outputs cross A2A (Agent-to-Agent) boundaries
+- **Bridge-code (MSS)** — every module carries contentType, structure, mechanics, boundary, scale tags
+- **Coordination via protocol** — agents coordinate through A2A, not through a shared platform service
+- **BP is the single policy engine** — the same block predicates govern local execution and inter-agent sharing
+
+This doesn't preclude centralized hosting. Like websites, modules need to live somewhere with internet access — a cloud server, a company's infrastructure, or a home device. Sovereignty means the user (or organization) controls the node and its policies, not that everything runs on local hardware. A business can deploy modnet nodes for each worker, creating an internal emergent network of personal agents operating within organizational policy — the architecture scales from individual to enterprise.
+
+Several of the critique's gaps dissolve when viewed through modnet's sovereignty model rather than shared-platform assumptions. Others require targeted extensions that compose naturally with existing primitives.
+
+---
+
+## Gap 1: Post-Execution Verification
+
+**Critique:** After execution — did the system evolve correctly? Did the service behave in staging? Did the canary show regressions?
+
+**Resolution: Attestation layer + commit-as-hyperedge + git hooks**
+
+This is a genuine gap. The existing defense-in-depth (6 layers in `SAFETY.md`) is entirely pre-execution. A third layer of hypergraph vertices — **attestation vertices** — closes it.
+
+### Three Layers of Hypergraph Vertices
+
+The hypergraph currently has two layers. The attestation layer adds a third:
+
+| Layer | Vertex Types | Produced By | Purpose |
+|---|---|---|---|
+| **Design-time** | Skill, Thread, Event, Tool, Rule, GovernanceRule | `collect_metadata` + source scan | What the agent *can* do |
+| **Runtime** | Session, SelectionDecision, Bid | `useSnapshot` | What the agent *decided* |
+| **Attestation** | GateDecision, ExecutionRecord, VerificationResult, UserApproval + skill-extended types | `useFeedback` handlers | What the *system state* actually is |
+
+### Core Evidence Types
+
+Every attestation vertex shares a base shape — an `@type`, a `verdict`, a link to the decision it verifies (`attestsTo`), and references to concrete artifacts with content hashes:
+
+```jsonc
+{
+  "@id": "evidence://sess_abc/verify_tc-3",
+  "@type": "VerificationResult",
+  "attestsTo": "bp:decision/D-42",
+  "producedBy": "tools:bash",
+  "verdict": "pass",
+  "artifacts": [
+    { "path": "test-output.log", "hash": "sha256:abc..." }
+  ],
+  "summary": "12 tests passed, 0 failed",
+  "boundary": "ask",
+  "scope": "modules/farm-stand",
+  "timestamp": "2026-03-11T14:30:00Z"
+}
+```
+
+Six core types map to pipeline stages:
+
+| `@type` | Pipeline Step | What It Attests |
+|---|---|---|
+| `GateDecision` | Gate (3) | Risk tags evaluated, preconditions checked |
+| `SimulationPrediction` | Simulate (4) | Predicted state changes |
+| `EvaluationJudgment` | Evaluate (5) | Symbolic + neural assessment |
+| `ExecutionRecord` | Execute (6) | Raw tool output, exit code |
+| `VerificationResult` | Verify (new) | Post-execution state check |
+| `UserApproval` | Human-in-loop | Explicit owner confirmation |
+
+The first four already have BP events (`gate_approved`, `simulation_result`, `eval_approved`, `tool_result`). They fire, handlers act on them, but the attestation is ephemeral. Persisting them as JSON-LD evidence vertices in `.memory/` makes them queryable for meta-verification and training.
+
+Extended types (`TestResult`, `TypeCheckResult`, `DeploymentRecord`, `HealthCheck`, etc.) are contributed by skills that merge their own `@context` vocabulary — the same mechanism that already powers skill subgraphs.
+
+### Git Hooks as Structural Verification
+
+For local module state, git hooks are the natural post-execution verification mechanism. The agent executes `git commit` via the `bash` tool. The pre-commit hook runs inside `Bun.$`. The `tool_result` carries stdout, stderr, and exit code — the handler parses these into evidence vertices.
+
+Current hooks enforce formatting (biome) and commit message format (commitlint). The Code Quality Gate in `AGENTS.md` mandates type checking (`tsc --noEmit`) and testing (`bun test src/`), but these are instructional — not structurally enforced by hooks. Moving them into the pre-commit hook is the neuro-symbolic migration the architecture describes: a pattern the model was told to follow becomes a constraint it cannot bypass.
+
+```sh
+# .hooks/pre-commit (upgraded)
+#!/bin/sh
+npx lint-staged                    # formatting: biome
+bun --bun tsc --noEmit            # type correctness
+bun test src/                      # test passing
+```
+
+Hook failures produce evidence with `verdict: 'fail'`, feed back to the model via `tool_result`, and the model re-plans. Hook successes produce evidence with `verdict: 'pass'` — proof that the commit passed structural verification at commit time.
+
+### The Commit as Evidence Hyperedge
+
+Per-side-effect commits (from `HYPERGRAPH-MEMORY.md`) already bundle code artifacts alongside decision JSON-LD files. Making the commit a first-class hypergraph vertex connects three things that are currently unlinked:
+
+```jsonc
+{
+  "@id": "git:a1b2c3d",
+  "@type": "Commit",
+  "attestsTo": ["bp:decision/D-42", "bp:decision/D-43"],
+  "artifacts": [
+    { "path": "src/agent/agent.types.ts", "action": "modified" },
+    { "path": ".memory/sessions/sess_abc/D-42.jsonld", "action": "added" }
+  ],
+  "hookResults": [
+    { "@type": "FormatResult", "verdict": "pass", "producedBy": "pre-commit:biome" },
+    { "@type": "TypeCheckResult", "verdict": "pass", "producedBy": "pre-commit:tsc" },
+    { "@type": "TestResult", "verdict": "pass", "producedBy": "pre-commit:test" }
+  ],
+  "message": "feat: add evidence vertex taxonomy",
+  "session": "session/sess_abc"
+}
+```
+
+The commit hash is immutable. The decision chain is linked via `attestsTo`. The verification results are embedded. Meta-verification can walk this structure to check that evidence exists and coheres.
+
+### Cross-Module Consistency
+
+The workspace is a monorepo (node root with `modules/` as Bun workspaces). When the agent commits a change to a module, the `tool_result` handler discovers which modules depend on the changed module (scanning `package.json` for `workspace:*` references), triggers test runs for each dependent, and persists the results as `CrossModuleTestResult` evidence vertices.
+
+This uses the batchCompletion pattern — each dependent's test run is a parallel operation, coordinated by a bThread that waits for all to complete before triggering a verification summary. Failed dependents feed back to context for the model to fix.
+
+The verification depth is configurable via DAC governance factories: direct dependents only (default), full transitive graph, or skip for routine changes. The MAC layer enforces the minimum — the changed module's own tests must pass.
+
+---
+
+## Gap 2: No System State Model
+
+**Critique:** The environment is overlapping graphs — goal, artifact, resource, authority, operational — and the agent's job is to move them forward without breaking invariants.
+
+**Resolution: Already exists — modnet module graph + bridge-code + hypergraph**
+
+The critique describes five graphs. All five already have modnet equivalents:
+
+| Critique Graph | Modnet Equivalent | Where Documented |
+|---|---|---|
+| Goal graph | Plan bThreads — step dependencies are `waitFor`/`block` in the BP engine | `HYPERGRAPH-MEMORY.md` |
+| Artifact graph | Modules with MSS contentType tags (`test-result`, `build-output`, etc.) | `MODNET-IMPLEMENTATION.md` |
+| Resource graph | Peer agents (Agent Cards) + module dependencies (`workspace:*`) | `MODNET-IMPLEMENTATION.md` |
+| Authority graph | ABAC predicates + known-peers table + boundary tags | `MODNET-IMPLEMENTATION.md` § Access Control |
+| Operational graph | Modules with operational contentType tags — skill-contributed | Extension via `@context` |
+
+In modnet, everything the agent works with is a **module** with bridge-code tags. Test results, security scans, deployment records — they're all modules or attestation vertices with contentType, structure, boundary, and scale. The hypergraph vertex taxonomy extends to cover them via JSON-LD `@context` vocabulary contributed by skills. No new architecture needed — the existing module model and `@context` extension mechanism handle it.
+
+What was missing was acknowledging this in `correct-behavior-analysis.md` and surfacing the connection between evidence artifacts and the existing module/vertex model. The attestation layer (Gap 1) provides the concrete implementation.
+
+---
+
+## Gap 3: Evidence-Backed Meta-Verification
+
+**Critique:** Instead of asking "how confident are we in this score," ask "does the evidence behind this decision actually exist and is it coherent?"
+
+**Resolution: Evidence vertices with `attestsTo` + `artifacts` enable graph-based verification**
+
+The current `withMetaVerification` wrapper produces `{ confidence, reasoning? }` — a grader-confidence score. This is necessary but insufficient. With attestation vertices persisted in the hypergraph, meta-verification extends to evidence-chain validation:
+
+1. **Existence check**: Do all referenced evidence vertices resolve? A `GraderResult` that claims tests passed should link to `TestResult` vertices via `@id`.
+2. **Artifact integrity**: Do content hashes in `artifacts` arrays match actual files? If a `TestResult` references `test-output.log` with hash `sha256:abc`, does the file exist and match?
+3. **Verdict coherence**: Are verdicts internally consistent? If evidence includes a `TestResult` with `verdict: 'fail'`, but the grader's outcome score is 0.9, the meta-verifier flags the inconsistency.
+
+This shifts meta-verification from "how confident is the grader?" to "does the evidence chain hold?" — exactly what the critique asks for. The existing `confidence` score remains useful as one signal, but it's grounded in verifiable evidence rather than self-assessment.
+
+---
+
+## Gap 4: Resource-Action-Condition Authority
+
+**Critique:** Autonomy is a function of delegated authority. Permissions are contextual and scoped — deploy to staging if checks pass, but production needs additional approval.
+
+**Resolution: ABAC already designed — extend scope from A2A to local execution**
+
+The critique describes Attribute-Based Access Control. The architecture already has ABAC — it's documented in `MODNET-IMPLEMENTATION.md` § Access Control and implemented as BP block predicates evaluating requester attributes + module attributes + context. The three-layer model (DAC + MAC + ABAC) is designed and the code pattern is specified.
+
+| Critique Term | Existing Modnet Primitive |
+|---|---|
+| Resource | Module (with contentType, structure, boundary tags) |
+| Action | Event type (`share_module`, `execute`, etc.) |
+| Condition | Context attributes evaluated by BP predicates |
+
+The gap is **scope**: ABAC is currently applied only to inter-agent `share_module` events. Extending it to local `execute` events means gate bThread predicates evaluate not just the tool call and its risk tags, but also the resource being targeted and whether preconditions are met.
+
+With the attestation layer, preconditions become evidence queries: "block deployment to production unless a `TestResult` with `verdict: 'pass'` exists for this session." This is a bThread block predicate that inspects the hypergraph for evidence state:
+
+```typescript
+bThreads.set({
+  requireTestsBeforeDeploy: bThread([
+    bSync({
+      block: (e) => {
+        if (e.type !== AGENT_EVENTS.execute) return false
+        if (!isDeploy(e.detail?.toolCall)) return false
+        return !hasEvidence({ type: 'TestResult', verdict: 'pass', session: currentSession })
+      },
+    }),
+  ], true),
+})
+```
+
+No new authority model needed. ABAC block predicates + evidence vertices + existing risk tags compose to provide resource-action-condition authority. The authority isn't "can you use bash?" — it's "can you deploy to production given the current evidence state?"
+
+---
+
+## Gap 5: Data Governance
+
+**Critique:** Data should carry labels — classification, residency, retention — and the system should know whether the agent is permitted to interact with that class of data.
+
+**Resolution: MSS bridge-code IS data governance**
+
+Every modnet module carries five MSS tags. Three of them directly address data governance:
+
+| Critique Concept | MSS Tag | How It Works |
+|---|---|---|
+| Data classification | `contentType` | Identifies the data domain — `"credentials"`, `"health-data"`, `"financial"`. MAC bThreads block access to classified types. |
+| Data residency | Node sovereignty | Data lives on the user's node, nowhere else. The node IS residency. Data doesn't leave unless the boundary tag permits it. |
+| Sharing policy | `boundary` | `all` / `none` / `ask` / `paid`. Controls what crosses A2A boundaries. MAC overrides — credentials are blocked regardless of boundary setting. |
+| Code/data separation | MSS architecture | Code never crosses A2A boundaries. Only `data/` contents are eligible for sharing. |
+| Access control | DAC + MAC + ABAC | Three-layer evaluation for every sharing request. |
+
+What the architecture doesn't have is **retention policy** — when to archive or delete data. This is partially addressed by hypergraph rotation (`TRAINING.md` § Log Retention): time-based or size-based rotation moves old decision files into compressed archives. Extending retention to module data would add a `retention` property to MSS bridge-code — but this is a minor addition to an existing model, not a new architecture.
+
+The critique's concern about data governance assumes a platform context where user data is centralized and needs classification to prevent misuse. In modnet, data is sovereign by default — it starts private on the user's node and only crosses boundaries through explicit, BP-gated sharing. The governance model is inverted: not "classify to protect" but "everything is protected; classify to share."
+
+---
+
+## Gap 6: Composite Process Signal
+
+**Critique:** BP snapshots are "one verifier among several" — they capture local coordination decisions, not broader system impact.
+
+**Resolution: Attestation vertices extend the process signal without diminishing BP snapshots**
+
+The critique is correct that BP snapshots alone don't capture broader system impact. But it underestimates what they capture. BP's event selection algorithm (`e ∈ ⋃ R_i(q_i) − ⋃ B_i(q_i)`) provides a formal composition guarantee — thread position IS state, blocking takes absolute precedence via set subtraction, and additive composition is a mathematical property, not a runtime hope. Within the agent's coordination boundary, BP snapshots are not just "one signal" — they are deterministic proof of every decision.
+
+That said, the process dimension in `GradingDimensions` should be a composite signal. The attestation layer provides additional signal sources:
+
+| Signal Source | What It Captures | Type | Weight |
+|---|---|---|---|
+| BP snapshots | Coordination decisions (blocked, interrupted, selected) | Deterministic | Foundation |
+| Git hook results | Type correctness, test passing, formatting | Deterministic | High |
+| Cross-module test results | Dependent module integrity | Deterministic | Medium |
+| Evidence chain integrity | Artifact hashes valid, verdicts coherent | Deterministic | High |
+| User approval/rejection | Semantic correctness | Human judgment | Highest |
+
+The training weight formula remains `outcome × process`, but `process` is now a weighted composite of BP snapshots + evidence verdicts. BP snapshots provide the foundation (free, deterministic, always available). Evidence vertices extend coverage to module state. User feedback provides irreducible semantic signal.
+
+This composite doesn't require a learned PRM — all signal sources except user feedback are deterministic. The composite just broadens the surface area of what "process quality" measures.
+
+---
+
+## Gap 7: Control-Plane Integration
+
+**Critique:** Steering enterprise agents is a control-plane problem. Guardrails need to be visible in logs, enforceable by policy, and explainable during an audit.
+
+**Resolution: BP enforcement + A2A coordination compose into a distributed control plane**
+
+The critique envisions a centralized control plane — a platform service coordinating CI/CD, deployment approvals, monitoring, and cost budgets. The modnet architecture approaches this differently: each node governs itself through BP, and nodes coordinate through A2A protocol. But the operational concerns the critique raises are real and don't disappear.
+
+**CI/CD doesn't go away.** Modules need testing, building, and deploying regardless of where they're hosted. In modnet, CI/CD can be:
+
+- A peer agent (a build-and-test node that receives module code via A2A and returns evidence)
+- Infrastructure local to the node's host (git hooks, pre-commit checks, local test runners)
+- A managed service the node connects to (GitHub Actions, cloud CI — the node controls the pipeline config)
+
+The key difference: the CI/CD pipeline serves the node, not the other way around. Results flow back as evidence vertices, consumed by BP block predicates.
+
+**Modules need hosting.** Modnet has always been agnostic about where a node physically lives. Like a personal website, a node runs on infrastructure the user controls — cloud servers, company infrastructure, edge devices, or home hardware. "Sovereign" means the user controls the node's policies and data, not that everything runs offline. A hosting provider can pull down your node just as a hosting provider can pull down your website — but while it runs, you control it. This is fundamentally different from a platform where the operator controls the policies.
+
+**Businesses deploy modnet internally.** A company can provision modnet nodes for each worker, creating an internal emergent network of personal agents. Each worker's PM manages their modules, coordinates with peer PMs via A2A, and operates within organizational policy enforced through MAC bThreads pushed to all nodes. This is modnet at organizational scale — the architecture applies equally to sovereign individuals and to managed fleets within an enterprise.
+
+| Centralized Concept | Modnet Equivalent |
+|---|---|
+| CI/CD pipeline | Build agent (peer node), local git hooks, or managed CI service — results as evidence |
+| Deployment approval | A2A request to deploy agent — blocked by bThread until approval event |
+| Monitoring dashboard | Monitoring agent or hosted service — exposes metrics consumed by BP predicates |
+| Cost budget | Budget bThread — blocks `execute` when cost exceeds threshold |
+| Audit log | Hypergraph memory — append-only, git-versioned, per-node |
+| Organizational policy | MAC bThreads distributed to fleet nodes — immutable, centrally authored |
+
+The ACP interface (`AgentNode.trigger()` / `AgentNode.subscribe()`) supports external event sources. A peer agent's A2A message, a CI webhook, or a monitoring alert all arrive as `trigger()` calls. BP gates coordinate locally based on evidence from any source.
+
+Three properties the critique requires — visible in logs, enforceable by policy, explainable during audit — are provided:
+
+1. **Visible in logs**: `useSnapshot` captures every BP decision as JSON-LD. Attestation vertices capture every verification result. Both are git-versioned.
+2. **Enforceable by policy**: BP block predicates enforce policy deterministically. MAC bThreads cannot be overridden. ABAC evaluates context.
+3. **Explainable during audit**: Each `SelectionBid` records which thread blocked which event and why. Each attestation vertex links to the decision it verifies and the artifacts that prove it. The full evidence chain is traversable.
+
+The control plane isn't absent — it's distributed. Each node governs itself; nodes coordinate through protocol. An organization can layer centralized policy (MAC bThreads) on top of this distributed substrate without contradicting the architecture.
+
+---
+
+## Module Architecture Evolution
+
+Subsequent exploration addressed the critique's remaining concerns through a fundamental rethinking of what a module IS. The result: modules as generative seeds with living interfaces, following the AgentSkills specification.
+
+### Modules Are AgentSkills (C+D Combined)
+
+The simple initial design (module = npm package = code) evolved into a combined architecture:
+
+- **Seed** (SKILL.md body) — the PM's internal knowledge: desired outcome, key decisions, constraints, eval criteria
+- **Interface** (references/interface.jsonld) — the module's external face: I/O contracts, relationships, mechanics
+- **Committed artifacts** (scripts/) — generated code, incrementally updated against a stable base
+
+The seed PRODUCES the interface. The PM GENERATES code from both. Artifacts are committed (not ephemeral) because AI generation is non-deterministic — committed code freezes the best generation and enables incremental diffs rather than blank-slate rebuilds.
+
+```
+modules/
+  farm-stand/
+    package.json                  ← name, MSS tags in "modnet" field
+    skills/
+      farm-stand/                 ← seed skill (named after module)
+        SKILL.md                  ← seed body + CONTRACT in metadata
+        scripts/                  ← committed generated code
+        references/               ← interface.jsonld, decisions.md
+        assets/                   ← grading.jsonl (eval criteria)
+      price-lookup/               ← additional capability skill
+        SKILL.md
+        scripts/
+    data/
+    .memory/
+```
+
+MSS bridge-code tags and CONTRACT fields live in the AgentSkills `metadata` field (arbitrary string key-value pairs, spec-compliant). This means modules validate with `bunx @plaited/development-skills validate-skill`, use the same progressive disclosure as framework skills, and feed the same distillation pipeline.
+
+### Sub-Agent Architecture (4-Step Harness)
+
+Sub-agents are separate `behavioral()` instances — not bThreads in the orchestrator's engine. Each has its own bThreads, context window, and inference. The PM (personal agent) coordinates them:
+
+1. **Decompose**: PM reads seed → breaks into sub-tasks
+2. **Parallelize**: Spawn sub-agent engines (Schema Designer, Implementer, UI Generator)
+3. **Verify**: Judge sub-agent evaluates against `assets/grading.jsonl`
+4. **Iterate**: On failure, spawn FRESH sub-agent with error context (new context window)
+
+The template is the existing UI↔Agent pattern — separate BP engines communicating via event bridges. `useRestrictedTrigger` creates bounded APIs between engines.
+
+### Mechanics-Driven Base Dynamics
+
+Rachel's structural IA defined person-object and person-person as base dynamics. In the personal agent model, ALL UI is generated by the user's PM — there is no shared interface. Person-person is subsumed by person-object as a content type handled by mechanics:
+
+| Dynamic | Scope |
+|---|---|
+| **Person-object** | ALL human-facing interaction. PM generates UI. Mechanics drive affordances. |
+| **Object-object** | Module ↔ module coordination. BP events / A2A data sync. No UI. |
+
+The mechanics taxonomy replaces source classification:
+
+| Category | Mechanics | Triggers |
+|---|---|---|
+| **Data** | sort, filter, aggregate, export | Module data display |
+| **Social** | reply, react, forward, mention, thread | Inter-personal content via A2A |
+| **Governance** | accept, reject, approve, escalate | Authority decisions |
+| **Temporal** | notify, remind, expire, schedule | Time-sensitive content |
+
+When inter-personal content arrives via A2A, it carries social mechanics. The PM reads mechanics and generates appropriate affordances. A comment gets `[reply, react]`; inventory data gets `[sort, filter]`. Same rendering pipeline, different mechanics applied.
+
+### Scale as Transitive Dependency Circuit Breaker
+
+Rachel's S1–S8 scale hierarchy bounds dependency propagation:
+
+- **Same scale** (S3 → S3): regenerate consuming module's artifacts
+- **Adjacent scale** (S3 → S4 group): only if group-level CONTRACT affected
+- **Beyond**: no propagation — scale IS the circuit breaker
+
+CONTRACT `produces`/`consumes` in SKILL.md metadata makes the dependency DAG explicit. The PM queries metadata to determine impact scope.
+
+### Eliminated: `.meta.db` Sidecar
+
+The per-module SQLite sidecar was designed for discovering branded objects in human-written code. In the C+D model, the PM generated the code from a specification it already has — discovery is unnecessary. The PM reads SKILL.md `metadata` fields for module registry, cross-module queries, and dependency resolution. `.workspace.db` is likewise eliminated.
+
+### How This Strengthens Gap Resolutions
+
+| Gap | Original Resolution | Strengthened By |
+|---|---|---|
+| 1: Post-execution | Attestation layer + git hooks | Committed artifacts → stable hashes for evidence vertices |
+| 2: System state | Module graph + hypergraph | SKILL.md metadata IS the module registry (no sidecar indirection) |
+| 3: Meta-verification | Evidence chains | `assets/grading.jsonl` provides structured acceptance criteria |
+| 4: Authority | ABAC + evidence-gated | Mechanics taxonomy classifies available interactions per content type |
+| 5: Data governance | MSS bridge-code | Mechanics-driven dynamics extend governance to social/temporal interactions |
+| 6: Process signal | Evidence as additional signals | 4-step harness with judge sub-agents provides structured verification |
+| 7: Control plane | A2A coordination | PM + sub-agent architecture — PMs negotiate, sub-agents execute |
+
+### Emergent Networks
+
+**Intra-node**: PM detects compatible modules (same `contentType`, compatible `scale` in SKILL.md metadata) → spawns Aggregate Generator sub-agent → generates emergent S6+ structure with its own seed + interface.
+
+**Inter-node**: PMs exchange interface specs via A2A → each PM independently generates its user's view. No shared interface. The "farmer's market" isn't a place — it's a protocol where interface specs flow between PMs, each rendering sovereign views for their user.
+
+---
+
+## Remaining Open Area
+
+After resolving all seven gaps and the module architecture evolution, one area remains:
+
+### Retention Policy
+
+MSS bridge-code doesn't include a retention property. Hypergraph rotation (`TRAINING.md` § Log Retention) handles decision file lifecycle, but module-level data retention (when to archive, when to delete, regulatory compliance) would need an additional MSS tag or a governance factory pattern. This is a minor extension for enterprise deployments, not an architectural gap.
+
+---
+
+## Revised Architecture Summary
+
+The architecture addresses the critique's central argument — steering as a control-plane problem over system state — through the composition of existing primitives, the attestation layer, and the module architecture evolution:
+
+```mermaid
+graph TD
+    subgraph "PM Engine (persistent)"
+        COORD["Coordination bThreads<br/>taskGate, workerBatch, verifyLoop"]
+        CONST["Constitution<br/>MAC/DAC bThreads"]
+        REG["Module Registry<br/>from SKILL.md metadata"]
+    end
+
+    subgraph "Pre-Execution (existing)"
+        CTX["Context Assembly<br/>Layer 0: BP-orchestrated"]
+        GATE["Hard Gate<br/>Layer 1: Risk tags + ABAC + mechanics"]
+        SIM["Simulation<br/>Layer 4: Dreamer"]
+        EVAL["Evaluation<br/>Layer 5: Symbolic + Neural"]
+        SAND["Sandbox<br/>Layer 2: OS-level"]
+    end
+
+    subgraph "Post-Execution (attestation layer)"
+        EXEC["Execute → tool_result"]
+        HOOK["Git Hooks<br/>tsc, tests, biome"]
+        CROSS["Cross-Module Tests<br/>Scale-bounded propagation"]
+        EVID["Evidence Vertices<br/>Persisted in .memory/"]
+        COMMIT["Commit Hyperedge<br/>Decisions + committed artifacts + verdicts"]
+    end
+
+    subgraph "Sub-Agent Engines (ephemeral)"
+        WORKER["Workers<br/>separate behavioral instances"]
+        JUDGE["Judge<br/>assets/grading.jsonl"]
+    end
+
+    subgraph "Audit (existing, enriched)"
+        SNAP["useSnapshot<br/>BP decision log"]
+        HG["Hypergraph<br/>JSON-LD in git"]
+        META["Meta-Verification<br/>Evidence chain validation"]
+    end
+
+    COORD --> CTX
+    COORD -->|"spawn"| WORKER
+    COORD -->|"spawn"| JUDGE
+    WORKER -->|"result trigger"| COORD
+    JUDGE -->|"verdict trigger"| COORD
+    CTX --> GATE --> SIM --> EVAL --> SAND --> EXEC
+    EXEC --> HOOK --> EVID
+    EXEC --> CROSS --> EVID
+    EVID --> COMMIT
+    COMMIT --> HG
+    SNAP --> HG
+    HG --> META
+    META -.->|"feeds back"| CTX
+    REG -.->|"SKILL.md metadata"| GATE
+    CONST -.->|"blocks"| GATE
+
+    style EXEC fill:#f9f,stroke:#333
+    style HOOK fill:#f9f,stroke:#333
+    style CROSS fill:#f9f,stroke:#333
+    style EVID fill:#f9f,stroke:#333
+    style COMMIT fill:#f9f,stroke:#333
+    style WORKER fill:#e8d5f5,stroke:#333
+    style JUDGE fill:#e8d5f5,stroke:#333
+    style REG fill:#d5e8f5,stroke:#333
+```
+
+Pink nodes: attestation layer (new). Purple nodes: sub-agent architecture (new). Blue node: module registry from SKILL.md metadata (replaces sidecar). Everything else is existing architecture, now connected through evidence vertices and the PM coordination engine.
+
+The attestation layer extends verification from "did we prevent bad actions?" to "did the system evolve correctly?" The sub-agent architecture extends execution from "one engine does everything" to "PM coordinates specialist engines." The module registry extends discovery from "scan source files" to "read SKILL.md frontmatter."

--- a/docs/GAP-ANALYSIS.md
+++ b/docs/GAP-ANALYSIS.md
@@ -1,0 +1,136 @@
+# Gap Analysis: System-State Steering
+
+> **Status: RESOLVED** — All 7 gaps addressed. See `CRITIQUE-RESPONSE.md` for full resolutions. Module architecture evolution (C+D combined, AgentSkills alignment, mechanics-driven dynamics) further strengthens resolutions. Cross-references: `CRITIQUE-RESPONSE.md`, `SAFETY.md`, `TRAINING.md`, `CONSTITUTION.md`, `HYPERGRAPH-MEMORY.md`, `AGENT-LOOP.md`, `ARCHITECTURE.md`, `MODNET-IMPLEMENTATION.md`.
+
+## Core Thesis
+
+The critique validates BP hard constraints ("hard constraints outside the reward function") and deterministic process ground truth (BP snapshots are "real ground truth" and "valuable"). What it challenges is the **scope** of verification: the defense-in-depth is entirely pre-execution, and the training pipeline treats BP snapshots as the complete process signal when they only capture local coordination decisions.
+
+The overarching argument: **steering should operate around system state, not just reasoning traces.** Every agent action is a proposed mutation to a complex environment. Verification must cover whether the mutation was legitimate given the environment's constraints — not just whether the agent's internal coordination looked clean.
+
+## Gap 1: No Post-Execution Verification Layer
+
+**Critique:** After execution — did the service behave correctly in staging? Did load tests pass? Did the canary show regressions? Did error rates spike?
+
+**Current state:** SAFETY.md's 6 layers are all pre-execution: context assembly → gate → simulate → evaluate → sandbox → audit trail. Layer 3 (Hypergraph Recovery) is an audit log, not a verifier. The `tool_result` event carries output but nothing checks whether the system state is actually correct.
+
+**Affected docs:** SAFETY.md (no Layer 7), AGENT-LOOP.md (no post-execute verification step)
+
+**Fix shape:** A post-execution verification step that checks system state after `tool_result` — did the file actually get written correctly? Did the deployment succeed? Did tests still pass? Could be a 7th defense layer or a feedback loop from `tool_result` back through verification before the result enters history.
+
+## Gap 2: No System State Model (The "Overlapping Graphs")
+
+**Critique:** The environment is a set of overlapping graphs — goal, artifact, resource, authority, operational — and the agent's job is to move them forward without breaking invariants.
+
+**Current state:** HYPERGRAPH-MEMORY.md models agent-internal state (BP decisions, tool calls, plans as bThreads, context assembly). Vertices: `Context`, `Decision`, `Tool`, `Plan`, `File`, `Embedding`. These are all about what the agent did, not what the system looks like.
+
+**What's missing:**
+- **Artifact graph:** No model of test results, security scan outcomes, build artifacts, or their relationships
+- **Resource graph:** No model of services, datasets, APIs, or environments as entities the agent interacts with
+- **Operational graph:** No connection to deployments, metrics, incidents, or cost
+
+**Affected docs:** HYPERGRAPH-MEMORY.md (vertex types), ARCHITECTURE.md (no system model)
+
+**Fix shape:** Extend the hypergraph vertex taxonomy to include environment vertices — `Artifact` (test result, scan result, build output), `Resource` (service, dataset, API endpoint), `Deployment` (environment, status, metrics). These don't need to be stored in the hypergraph — they can be referenced via JSON-LD `@id` pointers to external systems (CI logs, monitoring dashboards, artifact registries).
+
+## Gap 3: Evidence-Backed Meta-Verification
+
+**Critique:** Instead of asking "how confident are we in this score," ask "does the evidence behind this decision actually exist and is it coherent?" If a grader claims a release is safe, verify that scans ran, tests passed, and the deployed artifact matches what was reviewed.
+
+**Current state:** `withMetaVerification` produces `{ confidence, reasoning? }` — a grader-confidence score. This asks "did the grader reason well?" not "does the supporting evidence exist?"
+
+**Affected docs:** TRAINING.md (§ Meta-Verification), `correct-behavior-analysis.md` (§ Meta-Verification)
+
+**Fix shape:** Meta-verification should also check for evidence links. A `GraderResult` should reference the artifacts that support it — the test run ID, the scan report path, the deployment record. The verifier then checks whether those references resolve to actual, coherent evidence.
+
+## Gap 4: Authority Model is Tool-Level, Not Resource-Action-Condition Level
+
+**Critique:** Autonomy is a function of delegated authority, not model capability. Permissions are contextual and scoped — deploy to staging if checks pass, but production needs additional approval.
+
+**Current state:** SAFETY.md has the three-axis model (Capability × Autonomy × Authority), and risk tags route actions (`workspace` → skip sim, `crosses_boundary` → full pipeline). CONSTITUTION.md has MAC/DAC. But the authority model operates at the tool level — can you use `bash`? — not at the resource-action-condition level.
+
+**Affected docs:** SAFETY.md (authority axis), AGENT-LOOP.md (gate step), `agent.constants.ts` (risk tags)
+
+**Fix shape:** Risk tags need a resource dimension. Not just "this is a `bash` command with `crosses_boundary` tag" but "this is a `bash` command that deploys to `staging` — which requires `tests_passed` as a precondition." Gate bThread predicates could inspect not just the tool call and its tags, but also the resource being targeted and whether preconditions (evidence from artifact verification) are met.
+
+## Gap 5: No Data Governance Model
+
+**Critique:** Data should carry labels — classification, residency, retention — and the system should know whether the agent is permitted to interact with that class of data.
+
+**Current state:** TRAINING.md mentions a PII boundary (sanitization in the training wrapper). PROJECT-ISOLATION.md has hard process boundaries. Data is treated as "files in a project" — no classification, no residency constraints, no retention policy.
+
+**Affected docs:** SAFETY.md (no data axis in risk model), CONSTITUTION.md (no data-aware governance factories), HYPERGRAPH-MEMORY.md (no data classification on vertices)
+
+**Fix shape:** Data classification could operate at multiple levels:
+- Tool-level: tools that access classified data carry additional risk tags
+- Resource-level: the resource graph labels datasets/APIs with classification metadata
+- Constitution-level: governance factories that block access to data above the agent's clearance
+
+## Gap 6: BP Snapshots Overweighted in Training Design
+
+**Critique:** BP snapshots are "one verifier among several" — they capture local coordination decisions, not broader system impact. Valuable, but not the complete picture.
+
+**Current state:** TRAINING.md and `correct-behavior-analysis.md` present BP snapshots as the process signal that replaces learned PRMs entirely. The training weight formula (`outcome × process`) derives process from BP snapshots alone.
+
+**Affected docs:** TRAINING.md (§ Augmented Self-Distillation), `correct-behavior-analysis.md` (throughout)
+
+**Fix shape:** The process dimension in `GradingDimensions` should be a composite signal:
+
+| Signal Source | What It Captures | Type |
+|---|---|---|
+| BP snapshots | Local coordination decisions (blocked, interrupted, selected) | Deterministic |
+| Artifact checks | Did tests pass? Did scans run? | Deterministic |
+| Environment checks | Did deployment succeed? Did staging behave correctly? | Empirical |
+| Governance checks | Did the agent stay within delegated authority? Cross data boundaries? | Deterministic |
+| Operational checks | Post-deployment stability, error rates, cost | Empirical |
+
+BP snapshots remain the foundation (free and deterministic), but acknowledged as one layer of process verification, not the entire process signal.
+
+## Gap 7: No Control-Plane Integration with External Systems
+
+**Critique:** Steering enterprise agents is a control-plane problem. Guardrails need to be visible in logs, enforceable by policy, and explainable during an audit — independently of the model.
+
+**Current state:** BP IS a control plane — but for the agent's internal coordination. No concept of the agent participating in a broader organizational control plane (CI/CD gates, deployment approval workflows, incident management, cost budgets).
+
+**Affected docs:** ARCHITECTURE.md (no external control-plane integration), AGENT-LOOP.md (no connection to organizational systems)
+
+**Fix shape:** The ACP interface (`AgentNode`) already has `trigger`/`subscribe` — external systems could participate as event sources. A CI/CD system could `trigger({ type: 'deployment_approved', detail: { environment: 'staging', evidence: [...] } })`. Gate bThread predicates could block `execute` for deployment actions until the organizational control plane has approved.
+
+## What the Critique Validates
+
+Two areas where the architecture directly addresses the critique's concerns:
+
+1. **Hard constraints outside reward** — BP block predicates are exactly what the critique calls for. The neuro-symbolic split in CONSTITUTION.md: structural rules reject outright, reward shapes behavior among allowed actions.
+
+2. **Deterministic process ground truth** — BP snapshots are genuinely valuable and "real ground truth." The critique says they're one layer, not the whole answer.
+
+## Resolution Status
+
+All gaps resolved in `CRITIQUE-RESPONSE.md`:
+
+| Gap | Resolution | Strengthened By |
+|---|---|---|
+| 1: Post-execution verification | Attestation layer + commit-as-hyperedge + git hooks | Committed artifacts (stable hashes for evidence) |
+| 2: System state model | Modnet module graph + bridge-code + hypergraph | Modules as AgentSkills (SKILL.md metadata IS the registry, no sidecar) |
+| 3: Evidence-backed meta-verification | Evidence vertices with `attestsTo` + `artifacts` | Committed artifacts + eval criteria in `assets/grading.jsonl` |
+| 4: Resource-action-condition authority | ABAC + evidence-gated bThread predicates | Mechanics taxonomy classifies available interactions |
+| 5: Data governance | MSS bridge-code IS data governance | Mechanics-driven dynamics (Variant 3) — social/governance/temporal mechanics |
+| 6: Composite process signal | Evidence vertices as additional signal sources | 4-step harness (decompose/parallelize/verify/iterate) with judge sub-agents |
+| 7: Control-plane integration | A2A coordination between sovereign agents | PM + sub-agent architecture — PMs coordinate, sub-agents execute |
+
+### Previously Open Areas (Now Resolved)
+
+- **Transitive dependency** → Scale (S1-S8) as circuit breaker for dependency propagation. CONTRACT `produces`/`consumes` in SKILL.md metadata makes dependency DAG explicit.
+- **External system state** → A2A queries to peer agent PMs. Each PM manages its own modules; external state queries are A2A requests.
+- **Semantic correctness** → Irreducibly human. `UserApproval` evidence type. PM presents results and collects user judgment.
+- **Retention policy** → Minor MSS extension. Not architectural.
+
+## Priority Order (Original)
+
+1. **Post-execution verification** (Gap 1) — most immediately actionable, fits into existing defense-in-depth
+2. **Evidence-backed meta-verification** (Gap 3) — enhances existing mechanism
+3. **Composite process signal** (Gap 6) — broadens existing training design
+4. **Resource-action-condition authority** (Gap 4) — extends existing risk tags
+5. **System state model** (Gap 2) — significant design work, JSON-LD `@id` references keep it lightweight
+6. **Control-plane integration** (Gap 7) — ACP already supports this, needs design
+7. **Data governance** (Gap 5) — largest new design surface, enterprise-tier concern

--- a/docs/MODNET-IMPLEMENTATION.md
+++ b/docs/MODNET-IMPLEMENTATION.md
@@ -37,16 +37,18 @@ node/                               ← git repo (.gitignore excludes modules/)
   package.json                      ← "workspaces": ["modules/*"], "private": true
   bun.lock                          ← human-readable lockfile
   tsconfig.json
-  .workspace.db                     ← rebuilt from sidecars via ATTACH
   modules/
     apple-block/                    ← git repo (independent of node .git)
       .git/
       .memory/                      ← module-scoped decisions (tool results, code changes)
         sessions/
       package.json                  ← name: "@node/apple-block", "modnet": { MSS tags }
-      .meta.db                      ← per-module sidecar, committed to module repo
-      apple.ts
-      apple.types.ts
+      skills/
+        apple-block/                ← seed skill (named after module)
+          SKILL.md                  ← seed body + CONTRACT in metadata
+          scripts/                  ← committed generated code
+          references/               ← interface.jsonld, decisions.md
+          assets/                   ← grading.jsonl (eval criteria)
       data/
         varieties.json
     farm-stand/                     ← git repo (independent of node .git)
@@ -54,13 +56,20 @@ node/                               ← git repo (.gitignore excludes modules/)
       .memory/                      ← module-scoped decisions
         sessions/
       package.json                  ← depends on "@node/apple-block": "workspace:*"
-      .meta.db                      ← per-module sidecar, committed to module repo
-      farm-stand.ts
-      farm-stand.template.tsx
-      farm-stand.behavior.ts        ← only this compiles for browser
+      skills/
+        farm-stand/                 ← seed skill
+          SKILL.md                  ← seed body + CONTRACT in metadata
+          scripts/                  ← committed generated code
+          references/               ← interface.jsonld
+          assets/                   ← grading.jsonl
+        price-lookup/               ← additional capability skill
+          SKILL.md
+          scripts/
       data/
         inventory.json
 ```
+
+Modules follow the AgentSkills specification. Each module has a `skills/` directory containing a seed skill (named after the module) and optional capability skills. MSS bridge-code tags and CONTRACT fields live in the `metadata` field of SKILL.md frontmatter (arbitrary string key-value pairs, spec-compliant). The PM reads SKILL.md metadata for module discovery, cross-module queries, and dependency resolution — no sidecar database needed.
 
 ### Package.json as Module Manifest
 
@@ -113,75 +122,30 @@ Bun runs TypeScript natively — no compilation needed for server-side module co
 
 Bun workspace resolution handles inter-module imports via symlinks. Each module declares its dependencies in `package.json` and can only import what it declares — standard npm semantics. The single `bun.lock` at the node root tracks the full dependency tree.
 
-### Package Sidecar (`.meta.db`)
+### Module Registry (SKILL.md Metadata)
 
-Each module contains a `.meta.db` SQLite sidecar — a small database committed to the module's git repo alongside the code it describes. The sidecar is populated by a collector tool that scans source files for branded objects (`$` identifiers) and indexes them for fast lookup.
+> **Supersedes:** The `.meta.db` per-module sidecar and `.workspace.db` workspace view documented in earlier revisions. In the C+D module architecture, the PM generates code from specifications it already has — source-file scanning for branded objects is unnecessary.
 
-**Why per-module sidecars (not a central db):**
+The PM reads SKILL.md `metadata` fields for module discovery, cross-module queries, and dependency resolution. MSS bridge-code tags (`contentType`, `structure`, `mechanics`, `boundary`, `scale`) and CONTRACT fields (`produces`, `consumes`) are stored as string key-value pairs in the AgentSkills `metadata` field:
 
-- **Data ownership aligns with module ownership** — the sidecar travels with the module. When a module is transported to another node, its metadata comes with it.
-- **No rebuild-from-source** — the sidecar is pre-indexed. The agent queries it directly without re-scanning source files.
-- **Git-diffable provenance** — changes to branded objects produce visible diffs in the sidecar, auditable in git history.
-- **No coordination** — each package's sidecar is independent. No lock contention, no merge conflicts across packages.
-
-**Sidecar schema:**
-
-```sql
--- Branded objects discovered by the collector tool
-CREATE TABLE branded_objects (
-  path       TEXT NOT NULL,           -- relative path within package
-  identifier TEXT NOT NULL,           -- brand emoji: 🦄 🪢 🎛️ 🎨 🏛️
-  name       TEXT NOT NULL,           -- export name or factory name
-  layer      TEXT,                    -- 'mac' | 'dac' (governance factories only)
-  metadata   TEXT,                    -- JSON blob for brand-specific fields
-  PRIMARY KEY (path, name)
-);
-
--- String constants extracted from source (not hardcoded in templates)
-CREATE TABLE constants (
-  key        TEXT PRIMARY KEY,        -- constant identifier
-  value      TEXT NOT NULL,           -- the string value
-  source     TEXT NOT NULL            -- file path where defined
-);
+```yaml
+---
+name: farm-stand
+description: Produce inventory management with filtering and sorting
+metadata:
+  contentType: produce
+  structure: list
+  mechanics: sort,filter
+  boundary: ask
+  scale: "3"
+  produces: inventory-data
+  consumes: apple-data
+---
 ```
 
-The `constants` table isolates string values that would otherwise be hardcoded in templates — event type strings, attribute names, error messages. This eliminates an injection vector (the agent cannot redefine constants by editing source) and enables future encryption of sensitive values.
+**Cross-module queries** use the same metadata: the PM scans `skills/*/SKILL.md` frontmatter to find modules by `contentType`, `scale`, or `produces`/`consumes` relationships. No SQLite, no collector tool, no workspace rebuild.
 
-**Workspace-level view (`.workspace.db`):**
-
-A `.workspace.db` at the node root provides cross-module queries by attaching all sidecars:
-
-```sql
--- Rebuilt on workspace init or after package changes
-ATTACH 'modules/apple-block/.meta.db' AS apple_block;
-ATTACH 'modules/farm-stand/.meta.db' AS farm_stand;
-
--- Cross-package query: find all governance factories
-SELECT * FROM apple_block.branded_objects WHERE identifier = '🏛️'
-UNION ALL
-SELECT * FROM farm_stand.branded_objects WHERE identifier = '🏛️';
-```
-
-The workspace db is ephemeral — it is rebuilt from sidecars, never the other way around. If deleted, it regenerates. If a sidecar is modified, the workspace view reflects the change on next attach.
-
-**Collector tool:**
-
-The collector scans a package's source files, identifies branded objects by their `$` property, and upserts the sidecar. It runs:
-- On package creation (agent generates a new module)
-- On governance factory changes (new rules added or modified)
-- On demand (agent tool call)
-
-The collector is a built-in agent tool — `collect_metadata` — that takes a package path and updates its `.meta.db`. No background daemon, no watch process.
-
-**Engine-agnostic interface:**
-
-SQLite is the initial engine — it's Bun-native (`bun:sqlite`), single-file, zero-config, and matches the access pattern (point queries, single writer, hundreds of rows). The query interface is designed to be engine-agnostic:
-
-- Queries return plain objects, not SQLite-specific cursors
-- Schema is simple enough to port to any relational or document store
-- If analytical workloads emerge (event log analysis, training data extraction), a columnar engine (DuckDB, chDB) can serve those queries without replacing SQLite for point lookups
-
-The decision on additional engines is deferred until real workload data reveals the need. Start with what's free and boring.
+**Validation:** Modules validate with `bunx @plaited/development-skills validate-skill` — the same tool that validates framework skills.
 
 ### Asset Management: Symlinks Over Git LFS
 
@@ -250,6 +214,89 @@ A2A is a transport-agnostic protocol for agent-to-agent communication with three
 **Streaming** uses SSE framing (`text/event-stream`) over POST — not GET. The browser's `EventSource` API cannot be used; streaming requires `fetch()` with `ReadableStream`. Each SSE `data:` line contains a JSON-RPC 2.0 response wrapping one of: `task`, `message`, `statusUpdate`, or `artifactUpdate`.
 
 **A2A maps naturally to BP's event model.** Request-response maps to `trigger` → `waitFor`. Streaming maps to SSE events → `trigger()` per event. Push notifications map to inbound webhook → `trigger()`. No separate adapter layer — A2A calls are tool calls flowing through the same Gate → Execute pipeline.
+
+### A2A Transport Strategy
+
+The A2A spec (v1.0.0) requires encrypted communication for production but is transport-agnostic. The spec explicitly supports custom protocol bindings, including WebSocket (`protocolBinding: "WEBSOCKET"`). The requirement is **encryption**, not specifically HTTPS — `wss://` satisfies it for WebSocket, and unix sockets need no encryption (traffic never leaves the kernel).
+
+**Bun-native implementation** — no a2a-js dependency. `Bun.serve()` handles all A2A transport needs in a single server: HTTP (JSON-RPC/REST), WebSocket (custom binding for persistent connections), and unix sockets — all with native mTLS support.
+
+```typescript
+Bun.serve({
+  unix: "/tmp/a2a.sock",          // same-box: k8s pods, docker-compose
+  tls: { cert, key, ca },         // cross-network: mTLS
+  fetch(req, server) {
+    // A2A JSON-RPC/REST endpoints (Layer 3 binding)
+    // WebSocket upgrade for persistent A2A + UI
+    // Agent Card at /.well-known/agent-card.json
+  },
+  websocket: {
+    // A2A streaming (bidirectional, custom binding)
+    // UI controller protocol (generative UI)
+  },
+})
+```
+
+A2A Layers 1 (data model) + 2 (abstract operations) are implemented once. Layer 3 (protocol binding) varies by deployment context and interaction pattern.
+
+**By deployment (wire selection):**
+
+| Deployment | Wire | Security | Bun API |
+|---|---|---|---|
+| **Same box** (k8s pod, docker-compose) | Unix domain socket | OS-level (no network) | `Bun.serve({ unix })` + `fetch({ unix })` |
+| **Same cluster** (k8s services, docker network) | TCP over internal DNS | mTLS via cert-manager/Istio or direct | `Bun.serve({ tls })` + `fetch()` |
+| **Cross-network** (sovereign nodes) | TCP over internet | mTLS (`MutualTlsSecurityScheme`) | `Bun.serve({ tls })` + `fetch()` / `new WebSocket()` |
+
+**By interaction pattern (protocol selection):**
+
+| Pattern | Protocol | When |
+|---|---|---|
+| **One-shot** (query, lookup, single task) | HTTP+JSON POST | Default. Stateless, no connection overhead. |
+| **Streaming response** (task progress) | HTTP POST → SSE response (`text/event-stream`) | Standard A2A streaming. NOT `EventSource` (POST-initiated). `fetch()` + `ReadableStream`. |
+| **Active collaboration** (multi-turn negotiation) | WebSocket | Persistent bidirectional. Avoids repeated TLS handshake per message. |
+| **Async updates** (post-disconnect) | Webhook (HTTP POST back) | A2A native push notifications. |
+
+Transport is **per-interaction, not per-node.** A node can use HTTP for one task and WebSocket for another with the same peer. The Agent Card declares both via `supportedInterfaces`; the client selects based on interaction needs. WebSocket is an optimization for sustained collaboration, not a requirement. HTTP+JSON is the default.
+
+### A2A Interaction Strategy
+
+The five A2A operations compose into a hybrid interaction model — the spec used as designed:
+
+| A2A Operation | Wire | When |
+|---|---|---|
+| `POST /message:send` | HTTP POST → JSON response | One-shot. Short task, immediate result. |
+| `POST /message:stream` | HTTP POST → SSE response | Client wants real-time progress. Connection held until task completes. |
+| `POST /tasks/{id}:subscribe` | HTTP POST → SSE response | Client reconnects to in-progress task. Resumes from where it left off. |
+| Push notification (webhook) | Agent POSTs to client's registered URL | Client disconnects, gets notified async. Requires client to be a server. |
+| WebSocket (custom binding) | Persistent `wss://` connection | Active multi-turn collaboration. Replaces repeated POST + SSE cycles. |
+
+**Typical interaction flow:**
+
+```
+1. POST /message:send → taskId + ack           (fire-and-forget)
+2. Want real-time? POST /message:stream         (SSE, hold open)
+3. Connection drops? POST /tasks/{id}:subscribe (SSE, resume)
+4. Don't need real-time? Register webhook       (async POST back)
+5. Heavy collaboration? Upgrade to WebSocket    (persistent bidirectional)
+```
+
+Each operation is independent — the client picks the right one per interaction. No state machine needed. Every node is already a server (`Bun.serve()`), so receiving webhooks is free.
+
+**K8s same-box optimization:** Pods in the same deployment share a unix socket via `emptyDir` volume mount. Pods in different deployments use k8s Service DNS with mTLS. Same `Bun.serve()`, different wire.
+
+### Bun Networking Surface
+
+All networking primitives available for A2A and internal communication:
+
+| Bun API | Protocol | TLS | Unix Socket | Use For |
+|---|---|---|---|---|
+| `Bun.serve()` | HTTP + WebSocket server | Yes | Yes | A2A server, UI server, WebSocket upgrade |
+| `fetch()` | HTTP client | Yes | Yes | A2A client calls, inference server |
+| `Bun.listen()` | Raw TCP server | Yes | Yes | Custom binary protocol (future) |
+| `Bun.connect()` | Raw TCP client | Yes | Yes | Custom binary protocol (future) |
+| `Bun.udpSocket()` | UDP | No | No | Heartbeats, discovery (future) |
+| `Bun.spawn({ ipc })` | IPC (structured clone) | N/A | N/A | PM ↔ sub-agent |
+| `new WebSocket()` | WebSocket client | Yes (`wss://`) | No | A2A client to other nodes |
 
 ## Identity & Authentication
 

--- a/docs/PROJECT-ISOLATION.md
+++ b/docs/PROJECT-ISOLATION.md
@@ -116,6 +116,29 @@ useFeedback({
 })
 ```
 
+## Two Levels of `Bun.spawn()`
+
+The architecture uses `Bun.spawn()` at two distinct levels — project isolation and sub-agent coordination. They serve different purposes but use the same IPC mechanism:
+
+| Level | Purpose | Lifecycle | Spawned By |
+|---|---|---|---|
+| **Project subprocess** | Isolate codebases with different security contexts | Long-lived (reused across tasks) | Orchestrator |
+| **Sub-agent process** | Isolate inference + tool execution per sub-task | Ephemeral (per-task, fresh context) | PM engine within a project subprocess |
+
+A project subprocess contains the PM's `behavioral()` engine. The PM spawns sub-agents within that subprocess's context — sub-agents inherit the project's cwd, tool assembly, and constitution. The orchestrator doesn't manage sub-agents directly; it routes tasks to the right project, and the project's PM handles decomposition.
+
+```
+Orchestrator (behavioral())
+  └─ Project A (Bun.spawn)     ← long-lived, per-project
+       └─ PM Engine (behavioral())
+            ├─ Sub-agent 1 (Bun.spawn)  ← ephemeral, per-task
+            ├─ Sub-agent 2 (Bun.spawn)  ← ephemeral, per-task
+            └─ Judge (Bun.spawn)        ← ephemeral, per-verification
+  └─ Project B (Bun.spawn)
+       └─ PM Engine (behavioral())
+            └─ ...
+```
+
 ## What Isolation Provides
 
 | Concern | Solution |

--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
     "copy:css-types": "bash scripts/copy-css-types.sh",
     "dev": "bun --hot src/cli.ts dev src/ui",
     "prepare": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .hooks || true",
-    "test": "bun run test:stories src/ui && bun test src/",
+    "test": "bun test src/",
     "test:playwright": "bunx playwright test",
-    "test:stories": "bun src/cli.ts test",
-    "test:stories-ui": "bun run test:stories src/ui",
     "test:tools": "bun test src/tools/"
   },
   "lint-staged": {

--- a/skills/search-agent-skills/scripts/search.ts
+++ b/skills/search-agent-skills/scripts/search.ts
@@ -5,7 +5,7 @@
  */
 
 const MCP_URL = 'https://agentskills.io/mcp'
-const TOOL_NAME = 'SearchAgentSkills'
+const TOOL_NAME = 'search_agent_skills'
 
 const main = async () => {
   const raw = process.argv[2]

--- a/skills/search-agent-skills/scripts/search.ts
+++ b/skills/search-agent-skills/scripts/search.ts
@@ -20,7 +20,13 @@ const main = async () => {
     process.exit(2)
   }
 
-  const input = JSON.parse(raw)
+  let input: { query?: string }
+  try {
+    input = JSON.parse(raw)
+  } catch {
+    console.error('Invalid JSON input')
+    process.exit(2)
+  }
   if (!input.query) {
     console.error('Missing required field: query')
     process.exit(2)

--- a/skills/search-bun-docs/scripts/search.ts
+++ b/skills/search-bun-docs/scripts/search.ts
@@ -20,7 +20,13 @@ const main = async () => {
     process.exit(2)
   }
 
-  const input = JSON.parse(raw)
+  let input: { query?: string }
+  try {
+    input = JSON.parse(raw)
+  } catch {
+    console.error('Invalid JSON input')
+    process.exit(2)
+  }
   if (!input.query) {
     console.error('Missing required field: query')
     process.exit(2)

--- a/skills/search-bun-docs/scripts/search.ts
+++ b/skills/search-bun-docs/scripts/search.ts
@@ -5,7 +5,7 @@
  */
 
 const MCP_URL = 'https://bun.com/docs/mcp'
-const TOOL_NAME = 'SearchBun'
+const TOOL_NAME = 'search_bun'
 
 const main = async () => {
   const raw = process.argv[2]

--- a/skills/search-mcp-docs/scripts/search.ts
+++ b/skills/search-mcp-docs/scripts/search.ts
@@ -5,7 +5,7 @@
  */
 
 const MCP_URL = 'https://modelcontextprotocol.io/mcp'
-const TOOL_NAME = 'SearchModelContextProtocol'
+const TOOL_NAME = 'search_model_context_protocol'
 
 const main = async () => {
   const raw = process.argv[2]

--- a/skills/search-mcp-docs/scripts/search.ts
+++ b/skills/search-mcp-docs/scripts/search.ts
@@ -20,7 +20,13 @@ const main = async () => {
     process.exit(2)
   }
 
-  const input = JSON.parse(raw)
+  let input: { query?: string }
+  try {
+    input = JSON.parse(raw)
+  } catch {
+    console.error('Invalid JSON input')
+    process.exit(2)
+  }
   if (!input.query) {
     console.error('Missing required field: query')
     process.exit(2)

--- a/src/tools/tests/remote-mcp-client.spec.ts
+++ b/src/tools/tests/remote-mcp-client.spec.ts
@@ -21,7 +21,7 @@ describe('mcpListTools', () => {
   test('lists tools from bun-docs server', async () => {
     const tools = await mcpListTools(BUN_DOCS_URL)
     expect(tools.length).toBeGreaterThan(0)
-    const searchTool = tools.find((t) => t.name === 'SearchBun')
+    const searchTool = tools.find((t) => t.name === 'search_bun')
     expect(searchTool).toBeDefined()
     expect(searchTool?.inputSchema).toBeDefined()
   })
@@ -29,21 +29,21 @@ describe('mcpListTools', () => {
   test('lists tools from mcp-docs server', async () => {
     const tools = await mcpListTools(MCP_DOCS_URL)
     expect(tools.length).toBeGreaterThan(0)
-    const searchTool = tools.find((t) => t.name === 'SearchModelContextProtocol')
+    const searchTool = tools.find((t) => t.name === 'search_model_context_protocol')
     expect(searchTool).toBeDefined()
   })
 
   test('lists tools from agent-skills server', async () => {
     const tools = await mcpListTools(AGENT_SKILLS_URL)
     expect(tools.length).toBeGreaterThan(0)
-    const searchTool = tools.find((t) => t.name === 'SearchAgentSkills')
+    const searchTool = tools.find((t) => t.name === 'search_agent_skills')
     expect(searchTool).toBeDefined()
   })
 })
 
 describe('mcpCallTool', () => {
   test('searches bun-docs for Bun.file', async () => {
-    const result = await mcpCallTool(BUN_DOCS_URL, 'SearchBun', { query: 'Bun.file' })
+    const result = await mcpCallTool(BUN_DOCS_URL, 'search_bun', { query: 'Bun.file' })
     expect(result.content.length).toBeGreaterThan(0)
     const first = result.content[0]!
     expect(first.type).toBe('text')
@@ -51,7 +51,7 @@ describe('mcpCallTool', () => {
   })
 
   test('searches mcp-docs for tools/call', async () => {
-    const result = await mcpCallTool(MCP_DOCS_URL, 'SearchModelContextProtocol', {
+    const result = await mcpCallTool(MCP_DOCS_URL, 'search_model_context_protocol', {
       query: 'tools/call request',
     })
     expect(result.content.length).toBeGreaterThan(0)
@@ -60,7 +60,7 @@ describe('mcpCallTool', () => {
   })
 
   test('searches agent-skills for SKILL.md', async () => {
-    const result = await mcpCallTool(AGENT_SKILLS_URL, 'SearchAgentSkills', {
+    const result = await mcpCallTool(AGENT_SKILLS_URL, 'search_agent_skills', {
       query: 'SKILL.md frontmatter',
     })
     expect(result.content.length).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary

### What changed

- **`docs/CRITIQUE-RESPONSE.md`** (new) — Full response to 7 gaps identified in external critique of `correct-behavior-analysis.md`. Resolves all 7: 3 through existing design that was insufficiently surfaced (system state model via modnet, data governance via MSS bridge-code, control-plane integration via A2A), 3 through new composing extensions (attestation layer, evidence-backed meta-verification, composite process signal), 1 via ABAC scope extension.
- **`docs/GAP-ANALYSIS.md`** (new) — Systematic gap identification with resolution status table, priority order, and cross-references to affected docs. Status: all 7 resolved.
- **`docs/ARCHITECTURE.md`** — Runtime hierarchy section (`Bun.spawn → behavioral → bThread → bSync`), `SubAgentHandle` interface, local inference model via persistent `Bun.spawn()` process.
- **`docs/AGENT-LOOP.md`** — PM as central coordinator with sub-agents as `Bun.spawn()` processes; 4-step harness diagram (decompose → parallelize → verify → iterate) with judge sub-agents.
- **`docs/MODNET-IMPLEMENTATION.md`** — Module registry via SKILL.md metadata replaces `.meta.db` sidecar and `.workspace.db` (significant simplification); C+D module structure with `skills/` directories per module; Bun-native A2A transport strategy (unix socket / HTTP+JSON / WebSocket) with networking surface table.
- **`docs/PROJECT-ISOLATION.md`** — Two levels of `Bun.spawn()` (project-level vs sub-agent); nesting diagram showing orchestrator → project → PM → sub-agents.
- **`CLAUDE.md`** — Decided sections added: runtime hierarchy, local inference, module registry, A2A transport. `src/a2a/` added to planned modules. Build path updated.
- **`.mcp.json`** (new) — MCP server configuration: Streamable HTTP endpoints for AgentSkills spec, MCP docs, and Bun docs search.
- **`skills/search-*/scripts/search.ts`** — Fix tool names from PascalCase to snake_case (`SearchBun` → `search_bun`, etc.) to match what the remote MCP servers actually expose. Add `try/catch` around `JSON.parse` for clean exit code 2 on invalid input.
- **`src/tools/tests/remote-mcp-client.spec.ts`** — Update tool name assertions to match snake_case rename.
- **`package.json`** — Remove broken `test:stories` script (CLI test command was removed in the generative UI refactor); simplify `test` to `bun test src/`.
- **`AGENTS.md`** — Remove outdated docker test naming convention rule (`.docker.ts` pattern not used in practice).

### Why

Responding to an external critique that argued the architecture's defense-in-depth was entirely pre-execution and that BP snapshots were overweighted as process signal. The response validates what the critique affirms (BP block predicates as hard constraints outside reward, deterministic process ground truth), addresses genuine gaps (attestation layer for post-execution verification, composite process signal), and reframes others through the modnet sovereignty model. The module registry simplification (SKILL.md replaces `.meta.db`) falls out of the module architecture evolution documented here.

The MCP tool name fix unblocks the three search skills (`search-bun-docs`, `search-mcp-docs`, `search-agent-skills`) which were failing silently because they called PascalCase tool names that no longer exist on the servers.

### Breaking changes

None — docs only, plus test/tooling fixes.

### Testing notes

- `bun test src/tools/tests/remote-mcp-client.spec.ts` — live integration tests against external MCP servers; require network access
- `.mcp.json` uses `https://bun.com/docs/mcp` for the Bun docs server — **unverified URL** (may be `bun.sh` — confirm before relying on this endpoint)
- Architecture decisions are consistent with existing `src/agent/` production types

### Known follow-ups

- Verify correct Bun docs MCP URL (`bun.com` vs `bun.sh`)
- `src/tools/tests/remote-mcp-client.spec.ts` makes live external API calls with no timeout — could hang in CI if servers are unavailable
- `search-mcp-docs/scripts/search.ts` help text mentions a `version` field but the input type doesn't include it; silently accepted but not validated
- No error handling around the `Bun.$` shell call in search scripts — non-zero exit from `plaited remote-mcp-client` will throw unhandled

🤖 Generated with [Claude Code](https://claude.com/claude-code)