### PR TITLE
fix(cli): harden markdown parsing against redos

### DIFF
--- a/src/cli/utils/markdown.ts
+++ b/src/cli/utils/markdown.ts
@@ -2,7 +2,68 @@ import { normalize } from 'node:path'
 import { YAML } from 'bun'
 import type * as z from 'zod'
 
-const frontmatterRegex = /^---\s*[\r\n]([\s\S]*?)[\r\n]---\s*/
+type ParsedFrontmatterBlock = {
+  frontmatter: string
+  bodyStartIndex: number
+}
+
+const isFrontmatterDelimiterLine = (line: string): boolean => {
+  if (!line.startsWith('---')) return false
+  for (let index = 3; index < line.length; index++) {
+    const charCode = line.charCodeAt(index)
+    if (charCode !== 0x20 && charCode !== 0x09) return false
+  }
+  return true
+}
+
+const findLineEnd = (value: string, startIndex: number): number => {
+  for (let index = startIndex; index < value.length; index++) {
+    const charCode = value.charCodeAt(index)
+    if (charCode === 0x0a || charCode === 0x0d) return index
+  }
+  return -1
+}
+
+const skipLineBreak = (value: string, lineEndIndex: number): number => {
+  const charCode = value.charCodeAt(lineEndIndex)
+  if (charCode === 0x0d && value.charCodeAt(lineEndIndex + 1) === 0x0a) return lineEndIndex + 2
+  return lineEndIndex + 1
+}
+
+const trimTrailingLineBreak = (value: string): string => {
+  if (value.endsWith('\r\n')) return value.slice(0, -2)
+  if (value.endsWith('\n') || value.endsWith('\r')) return value.slice(0, -1)
+  return value
+}
+
+const parseFrontmatterBlock = (markdown: string): ParsedFrontmatterBlock | null => {
+  const openingLineEnd = findLineEnd(markdown, 0)
+  if (openingLineEnd === -1) return null
+
+  const openingLine = markdown.slice(0, openingLineEnd)
+  if (!isFrontmatterDelimiterLine(openingLine)) return null
+
+  const frontmatterStartIndex = skipLineBreak(markdown, openingLineEnd)
+  let lineStartIndex = frontmatterStartIndex
+
+  while (lineStartIndex < markdown.length) {
+    const lineEndIndex = findLineEnd(markdown, lineStartIndex)
+    const line = markdown.slice(lineStartIndex, lineEndIndex === -1 ? markdown.length : lineEndIndex)
+    if (isFrontmatterDelimiterLine(line)) {
+      const frontmatterWithTrailingLineBreak = markdown.slice(frontmatterStartIndex, lineStartIndex)
+      const bodyStartIndex = lineEndIndex === -1 ? markdown.length : skipLineBreak(markdown, lineEndIndex)
+      return {
+        frontmatter: trimTrailingLineBreak(frontmatterWithTrailingLineBreak),
+        bodyStartIndex,
+      }
+    }
+
+    if (lineEndIndex === -1) return null
+    lineStartIndex = skipLineBreak(markdown, lineEndIndex)
+  }
+
+  return null
+}
 
 /**
  * Consumes an `HTMLRewriter` result so link extraction side effects are applied.
@@ -43,13 +104,13 @@ export const parseMarkdownWithFrontmatter = <TSchema extends z.ZodType>(
     requireBody?: boolean
   },
 ): { frontmatter: z.infer<TSchema>; body: string } => {
-  const match = markdown.match(frontmatterRegex)
-  const frontmatter = match?.[1]
+  const parsedBlock = parseFrontmatterBlock(markdown)
+  const frontmatter = parsedBlock?.frontmatter
   if (!frontmatter) {
     throw new Error('Missing YAML frontmatter')
   }
 
-  const body = markdown.slice(match[0].length).trim()
+  const body = markdown.slice(parsedBlock.bodyStartIndex).trim()
   if (options?.requireBody !== false && !body) {
     throw new Error('Markdown body must not be empty')
   }

--- a/src/cli/utils/tests/markdown.spec.ts
+++ b/src/cli/utils/tests/markdown.spec.ts
@@ -60,6 +60,15 @@ description: A test skill
     )
   })
 
+  test('throws on large malformed frontmatter with many near-delimiter lines', () => {
+    const nearDelimiterLines = Array.from({ length: 20_000 }, () => '--- not-a-delimiter')
+    const markdown = `---
+${nearDelimiterLines.join('\n')}
+# Missing frontmatter delimiter`
+
+    expect(() => parseMarkdownWithFrontmatter(markdown, TestFrontmatterSchema)).toThrow('Missing YAML frontmatter')
+  })
+
   test('throws when the body is required but empty', () => {
     expect(() =>
       parseMarkdownWithFrontmatter(


### PR DESCRIPTION
## Context

- Narrow `code` card fix for CodeQL alert #14 (`js/polynomial-redos`, high)
  in `src/cli/utils/markdown.ts` line 46.

## Summary

- Replaced regex-based YAML frontmatter extraction with a bounded line-by-line
  delimiter scan to avoid polynomial backtracking behavior.
- Preserved expected behavior for valid frontmatter parsing, missing
  frontmatter errors, and required-body validation.
- Added targeted regression coverage for large malformed near-delimiter input.

## Changed Files

- `src/cli/utils/markdown.ts`
- `src/cli/utils/tests/markdown.spec.ts`

## Validation

- Targeted tests: `bun test src/cli/utils/tests/markdown.spec.ts` (15 pass, 0 fail)
- `bun --bun tsc --noEmit`: pass
- Formatting/lint: `bunx biome check --write src/cli/utils/markdown.ts src/cli/utils/tests/markdown.spec.ts`
  (pass; fixed 1 file)

## Known Failures / Drift

- `cline-pr-review` check failed in workflow context collection with
  `gh: Resource not accessible by integration (HTTP 403)`; this appears to be a
  workflow permission-path issue, not a failure caused by this code change.
- `pr-description-lint` previously failed due missing template headings; this
  PR body update addresses that.

## Review Notes / Residual Risks

- Repository alert list can still show alert #14 as open until GitHub rescans
  this PR branch; the code change is expected to clear it after rescan.
- Scope intentionally excludes workflow hardening in this slice.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
