### PR TITLE
fix(workflows): tolerate unavailable security context

### DIFF
--- a/.github/workflows/cline-pr-review.yml
+++ b/.github/workflows/cline-pr-review.yml
@@ -76,8 +76,14 @@ jobs:
           pr_checks="${RUNNER_TEMP}/plaited-pr-checks.txt"
           pr_checks_status="available"
           codeql_json="${RUNNER_TEMP}/plaited-codeql-alerts-open.json"
+          codeql_err="${RUNNER_TEMP}/plaited-codeql-alerts-open.err"
+          codeql_collection_status="available"
           dependabot_json="${RUNNER_TEMP}/plaited-dependabot-alerts-open.json"
+          dependabot_err="${RUNNER_TEMP}/plaited-dependabot-alerts-open.err"
+          dependabot_collection_status="available"
           secret_json="${RUNNER_TEMP}/plaited-secret-scanning-alerts-open.json"
+          secret_err="${RUNNER_TEMP}/plaited-secret-scanning-alerts-open.err"
+          secret_scanning_collection_status="available"
           changed_files="${RUNNER_TEMP}/plaited-pr-changed-files.txt"
 
           gh pr view "${PR_NUMBER}" \
@@ -91,9 +97,36 @@ jobs:
             } > "${pr_checks}"
           fi
 
-          gh api "repos/${GITHUB_REPO}/code-scanning/alerts?state=open&per_page=100" > "${codeql_json}"
-          gh api "repos/${GITHUB_REPO}/dependabot/alerts?state=open&per_page=100" > "${dependabot_json}"
-          gh api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_json}"
+          format_unavailable_reason() {
+            local err_file="$1"
+            local reason
+            reason="$(tr '\n' ' ' < "${err_file}" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | cut -c1-120)"
+            if [ -z "${reason}" ]; then
+              reason="request failed"
+            fi
+            echo "${reason}"
+          }
+
+          if gh api "repos/${GITHUB_REPO}/code-scanning/alerts?state=open&per_page=100" > "${codeql_json}" 2> "${codeql_err}"; then
+            codeql_collection_status="available"
+          else
+            codeql_collection_status="unavailable ($(format_unavailable_reason "${codeql_err}"))"
+            echo '[]' > "${codeql_json}"
+          fi
+
+          if gh api "repos/${GITHUB_REPO}/dependabot/alerts?state=open&per_page=100" > "${dependabot_json}" 2> "${dependabot_err}"; then
+            dependabot_collection_status="available"
+          else
+            dependabot_collection_status="unavailable ($(format_unavailable_reason "${dependabot_err}"))"
+            echo '[]' > "${dependabot_json}"
+          fi
+
+          if gh api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_json}" 2> "${secret_err}"; then
+            secret_scanning_collection_status="available"
+          else
+            secret_scanning_collection_status="unavailable ($(format_unavailable_reason "${secret_err}"))"
+            echo '[]' > "${secret_json}"
+          fi
 
           jq -r '.files[].path' "${pr_json}" | sort -u > "${changed_files}"
 
@@ -146,18 +179,22 @@ jobs:
             sed 's/^/- /' "${changed_files}"
             echo
             echo "## PR Checks"
-            echo "- Collection status: ${pr_checks_status}"
+            echo "- PR checks collection status: ${pr_checks_status}"
             echo '```text'
             cat "${pr_checks}"
             echo '```'
             echo
             echo "## Security Facts"
+            echo "- CodeQL collection status: ${codeql_collection_status}"
+            echo "- Dependabot collection status: ${dependabot_collection_status}"
+            echo "- Secret-scanning collection status: ${secret_scanning_collection_status}"
             echo "- CodeQL open alerts total: ${codeql_total}"
             echo "- CodeQL open high/critical alerts total: ${codeql_high_critical_total}"
             echo "- CodeQL open high/critical alerts touching changed files: ${codeql_high_critical_touched}"
             echo "- Dependabot open alerts total: ${dependabot_total}"
             echo "- Dependabot open high/critical alerts total: ${dependabot_high_critical_total}"
             echo "- Secret scanning open alerts total: ${secret_total}"
+            echo "- Unavailable security facts must be treated as residual risk / review finding."
             echo
             echo "## Raw Alert Payloads"
             echo "### CodeQL"

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -48,8 +48,14 @@ jobs:
           prs_file="${work_dir}/dev-merged-prs.json"
           checks_file="${work_dir}/dev-check-runs.json"
           codeql_file="${work_dir}/codeql-open-alerts.json"
+          codeql_err_file="${work_dir}/codeql-open-alerts.err"
+          codeql_collection_status="available"
           dependabot_file="${work_dir}/dependabot-open-alerts.json"
+          dependabot_err_file="${work_dir}/dependabot-open-alerts.err"
+          dependabot_collection_status="available"
           secret_file="${work_dir}/secret-scanning-open-alerts.json"
+          secret_err_file="${work_dir}/secret-scanning-open-alerts.err"
+          secret_collection_status="available"
           default_setup_file="${work_dir}/codeql-default-setup.json"
           body_file="${work_dir}/issue-body.md"
 
@@ -70,9 +76,38 @@ jobs:
             checks_collection_status="unknown (check-runs API request failed)"
             echo '{"check_runs":[]}' > "${checks_file}"
           fi
-          gh api "repos/${GITHUB_REPO}/code-scanning/alerts?state=open&per_page=100" > "${codeql_file}"
-          gh api "repos/${GITHUB_REPO}/dependabot/alerts?state=open&per_page=100" > "${dependabot_file}"
-          gh api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_file}"
+
+          format_unavailable_reason() {
+            local err_file="$1"
+            local reason
+            reason="$(tr '\n' ' ' < "${err_file}" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | cut -c1-120)"
+            if [ -z "${reason}" ]; then
+              reason="request failed"
+            fi
+            echo "${reason}"
+          }
+
+          if gh api "repos/${GITHUB_REPO}/code-scanning/alerts?state=open&per_page=100" > "${codeql_file}" 2> "${codeql_err_file}"; then
+            codeql_collection_status="available"
+          else
+            codeql_collection_status="unavailable ($(format_unavailable_reason "${codeql_err_file}"))"
+            echo '[]' > "${codeql_file}"
+          fi
+
+          if gh api "repos/${GITHUB_REPO}/dependabot/alerts?state=open&per_page=100" > "${dependabot_file}" 2> "${dependabot_err_file}"; then
+            dependabot_collection_status="available"
+          else
+            dependabot_collection_status="unavailable ($(format_unavailable_reason "${dependabot_err_file}"))"
+            echo '[]' > "${dependabot_file}"
+          fi
+
+          if gh api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_file}" 2> "${secret_err_file}"; then
+            secret_collection_status="available"
+          else
+            secret_collection_status="unavailable ($(format_unavailable_reason "${secret_err_file}"))"
+            echo '[]' > "${secret_file}"
+          fi
+
           gh api "repos/${GITHUB_REPO}/code-scanning/default-setup" > "${default_setup_file}"
 
           commit_count="$(wc -l < "${log_file}" | tr -d ' ')"
@@ -198,6 +233,15 @@ jobs:
           if [ "${checks_collection_status}" != "available" ]; then
             p1_items+=("dev branch checks status is unknown (${checks_collection_status})")
           fi
+          if [ "${codeql_collection_status}" != "available" ]; then
+            p1_items+=("CodeQL collection status is unavailable (${codeql_collection_status})")
+          fi
+          if [ "${dependabot_collection_status}" != "available" ]; then
+            p1_items+=("Dependabot collection status is unavailable (${dependabot_collection_status})")
+          fi
+          if [ "${secret_collection_status}" != "available" ]; then
+            p1_items+=("secret-scanning collection status is unavailable (${secret_collection_status})")
+          fi
           if [ "${query_suite}" != "extended" ]; then
             p1_items+=("CodeQL query suite is '${query_suite}', expected 'extended'")
           fi
@@ -240,7 +284,7 @@ jobs:
 
           required_human_checks=$'- Confirm release scope and version bump from commit intent.\n- Confirm no undisclosed security exceptions are being accepted.\n- Confirm validation evidence for changed runtime/package surfaces.\n- Confirm post-release main -> dev sync plan (merge commit, no reset/rebase/force-push).'
 
-          validation_summary="Dev checks_collection_status=${checks_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}."
+          validation_summary="Dev checks_collection_status=${checks_collection_status}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}."
 
           cat > "${body_file}" <<EOF
           ## Release Readiness Snapshot
@@ -269,6 +313,9 @@ jobs:
           validation_summary: ${validation_summary}
           main_to_dev_sync_required: ${main_to_dev_sync_required}
           security_summary:
+            codeql_collection_status: ${codeql_collection_status}
+            dependabot_collection_status: ${dependabot_collection_status}
+            secret_scanning_collection_status: ${secret_collection_status}
             codeql_open_by_severity: ${codeql_by_severity}
             dependabot_open_by_severity: ${dependabot_by_severity}
             secret_scanning_open_count: ${secret_total}
@@ -289,10 +336,14 @@ jobs:
 
           ## Deterministic Security Summary
 
+          - CodeQL collection status: \`${codeql_collection_status}\`
+          - Dependabot collection status: \`${dependabot_collection_status}\`
+          - Secret-scanning collection status: \`${secret_collection_status}\`
           - CodeQL open alerts by severity: \`${codeql_by_severity}\`
           - Dependabot open alerts by severity: \`${dependabot_by_severity}\`
           - Secret-scanning open alert count: \`${secret_total}\`
           - CodeQL query suite: \`${query_suite}\`
+          - Unavailable security facts are treated as residual risk and a P1 blocker.
           - Blocking security items:
           ${blocking_lines}
 

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -55,7 +55,7 @@ jobs:
           dependabot_collection_status="available"
           secret_file="${work_dir}/secret-scanning-open-alerts.json"
           secret_err_file="${work_dir}/secret-scanning-open-alerts.err"
-          secret_collection_status="available"
+          secret_scanning_collection_status="available"
           default_setup_file="${work_dir}/codeql-default-setup.json"
           body_file="${work_dir}/issue-body.md"
 
@@ -102,9 +102,9 @@ jobs:
           fi
 
           if gh api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_file}" 2> "${secret_err_file}"; then
-            secret_collection_status="available"
+            secret_scanning_collection_status="available"
           else
-            secret_collection_status="unavailable ($(format_unavailable_reason "${secret_err_file}"))"
+            secret_scanning_collection_status="unavailable ($(format_unavailable_reason "${secret_err_file}"))"
             echo '[]' > "${secret_file}"
           fi
 
@@ -239,8 +239,8 @@ jobs:
           if [ "${dependabot_collection_status}" != "available" ]; then
             p1_items+=("Dependabot collection status is unavailable (${dependabot_collection_status})")
           fi
-          if [ "${secret_collection_status}" != "available" ]; then
-            p1_items+=("secret-scanning collection status is unavailable (${secret_collection_status})")
+          if [ "${secret_scanning_collection_status}" != "available" ]; then
+            p1_items+=("secret-scanning collection status is unavailable (${secret_scanning_collection_status})")
           fi
           if [ "${query_suite}" != "extended" ]; then
             p1_items+=("CodeQL query suite is '${query_suite}', expected 'extended'")
@@ -284,7 +284,7 @@ jobs:
 
           required_human_checks=$'- Confirm release scope and version bump from commit intent.\n- Confirm no undisclosed security exceptions are being accepted.\n- Confirm validation evidence for changed runtime/package surfaces.\n- Confirm post-release main -> dev sync plan (merge commit, no reset/rebase/force-push).'
 
-          validation_summary="Dev checks_collection_status=${checks_collection_status}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}."
+          validation_summary="Dev checks_collection_status=${checks_collection_status}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_scanning_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}."
 
           cat > "${body_file}" <<EOF
           ## Release Readiness Snapshot
@@ -315,7 +315,7 @@ jobs:
           security_summary:
             codeql_collection_status: ${codeql_collection_status}
             dependabot_collection_status: ${dependabot_collection_status}
-            secret_scanning_collection_status: ${secret_collection_status}
+            secret_scanning_collection_status: ${secret_scanning_collection_status}
             codeql_open_by_severity: ${codeql_by_severity}
             dependabot_open_by_severity: ${dependabot_by_severity}
             secret_scanning_open_count: ${secret_total}
@@ -338,7 +338,7 @@ jobs:
 
           - CodeQL collection status: \`${codeql_collection_status}\`
           - Dependabot collection status: \`${dependabot_collection_status}\`
-          - Secret-scanning collection status: \`${secret_collection_status}\`
+          - Secret-scanning collection status: \`${secret_scanning_collection_status}\`
           - CodeQL open alerts by severity: \`${codeql_by_severity}\`
           - Dependabot open alerts by severity: \`${dependabot_by_severity}\`
           - Secret-scanning open alert count: \`${secret_total}\`


### PR DESCRIPTION
## Context

- Fixes the advisory workflow failure seen on PR #237 where `Collect deterministic PR/security context` exited on `gh: Resource not accessible by integration (HTTP 403)`.
- Scope is workflow hardening only (`tooling` card); no runtime source changes.
- Preserves advisory posture for Cline PR review and keeps workflow permissions minimal.

## Summary

- Hardened `.github/workflows/cline-pr-review.yml` deterministic security collection so each security API call is best-effort.
- On API failure, workflows now write `[]`, set explicit `*_collection_status="unavailable (<reason>)"`, and continue collecting deterministic context instead of crashing.
- Deterministic context now explicitly carries PR checks status, CodeQL/Dependabot/secret-scanning collection statuses, alert counts, and an explicit residual-risk statement for unavailable security facts.
- Mirrored best-effort security collection into `.github/workflows/release-readiness.yml` and escalated unavailable security fact collection to explicit `P1` blockers.
- Added security collection statuses to release-readiness `validation_summary`, `security_summary`, and deterministic security summary.
- No branch-mutating release automation was added.

## Changed Files

- `.github/workflows/cline-pr-review.yml`
- `.github/workflows/release-readiness.yml`

## Validation

- Targeted tests:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cline-pr-review.yml"); YAML.load_file(".github/workflows/release-readiness.yml"); puts "yaml ok"'` -> `yaml ok`
  - `rg -n "collection_status|unavailable|hide_secret=true|security_summary|P1|Resource not accessible|contents: write|actions: write|git push|gh pr create|gh pr merge" .github/workflows/cline-pr-review.yml .github/workflows/release-readiness.yml` -> expected hardening/status markers present; no `contents: write` or `actions: write` in these workflows
  - `biome check --write .github/workflows/cline-pr-review.yml .github/workflows/release-readiness.yml` -> `biome` not installed in PATH
  - `bunx biome check --write .github/workflows/cline-pr-review.yml .github/workflows/release-readiness.yml` -> Biome ignores these YAML paths in current config (0 files processed)
- `bun --bun tsc --noEmit`: skipped (workflow YAML-only changes; no TypeScript/runtime surface touched)

## Known Failures / Drift

- No blocking drift in this workflow-hardening slice.
- Current observed PR #238 status: `cline-pr-review`, `pr-description-lint`, and CodeQL checks are passing.
- `test-pr` is still pending and should be green before merge.

## Review Notes / Residual Risks

- Unavailable GitHub security APIs are now represented as explicit unknown/unavailable facts rather than causing hard workflow failure.
- In release-readiness, any unavailable security collection status is now treated as a `P1` blocker.
- Secret scanning remains `hide_secret=true`, and only the safe secret-scanning summary is included in Cline context.
- Cline review remains advisory/non-blocking (`continue-on-error: true`).

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests

