### PR TITLE
docs(workflow): clarify agent worktree placement

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -52,7 +52,15 @@ git merge --ff-only origin/dev
 ## 4. Development Lane
 
 - Cline Kanban is the primary local orchestration lane for Plaited agent work.
-- Each Kanban card should run in its own git worktree.
+- For manual agent-created worktrees, prefer `.worktrees/<card-or-task-slug>/`.
+- Start normal card work from fresh `origin/dev` unless a task explicitly says otherwise.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<slug>/` when prompted for a folder path.
+- Cline Kanban task worktrees are tool-managed and currently resolve under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
+- Do not force Kanban task worktrees into `.worktrees/` unless a future Kanban release exposes a
+  supported worktree-root configuration.
+- Existing sibling/external worktrees may finish where they are.
 - Keep slices narrow; avoid broad refactors unless explicitly requested.
 - Do not push directly to `main` for normal card work.
 - Fix forward and avoid reverting unrelated user/agent changes.
@@ -63,10 +71,14 @@ git merge --ff-only origin/dev
   `cleanup`, `eval`, and `autoresearch`.
 - Auto-commit and auto-PR are allowed for narrow, scoped cards.
 - Linked/dependent cards are allowed when file boundaries and sequencing are clear.
+- Kanban task worktree placement is currently tool-managed under `~/.cline/worktrees/...`.
+- Do not document `CLINE_DIR` as a Kanban task-worktree placement solution in current policy.
 - Move completed or abandoned cards to trash so ephemeral worktrees are cleaned up.
 - Review card diffs before landing any card output.
 - PRs opened from Kanban work should have the advisory Cline PR review workflow available.
 - Keep human approval for `dev -> main` promotion.
+- Keep branch strategy unchanged for card work: normal PRs target `dev`, squash into `dev`,
+  `main` remains the release branch, and never reset/rebase/force-push `dev`.
 
 ## 5.1 Card Taxonomy
 

--- a/.agents/skills/plaited-development/references/kanban-autoresearch-card.md
+++ b/.agents/skills/plaited-development/references/kanban-autoresearch-card.md
@@ -54,13 +54,19 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Run in an isolated git worktree with durable attempt artifacts.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
+- Keep manual and Kanban attempt artifacts durable and inspectable.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
 - Keep attempt outputs organized so failed and winning runs are inspectable.
 - Do not let experiment branches become long-lived shared branches.
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-cleanup-card.md
+++ b/.agents/skills/plaited-development/references/kanban-cleanup-card.md
@@ -25,12 +25,17 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Run in an isolated git worktree.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
 - Keep cleanup branch/card isolated from implementation work.
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-code-card.md
+++ b/.agents/skills/plaited-development/references/kanban-code-card.md
@@ -25,11 +25,16 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Run card work in an isolated git worktree.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-eval-card.md
+++ b/.agents/skills/plaited-development/references/kanban-eval-card.md
@@ -39,7 +39,11 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Execute eval cards in isolated worktrees.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
@@ -48,6 +52,7 @@ Worktree Expectations
 - Adopt winning results through a normal PR to `dev`.
 - Do not directly mutate `dev` from eval loops.
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-review-card.md
+++ b/.agents/skills/plaited-development/references/kanban-review-card.md
@@ -21,7 +21,14 @@ Required Repo Instructions
 - If no findings, state that explicitly and include residual risks/testing gaps.
 
 Worktree Expectations
-- Use isolated review worktree/session when needed.
+- Read-only review can run without creating a worktree.
+- If a manual review worktree is needed, prefer `.worktrees/<review-slug>/` from `origin/dev`.
+- For manual Cline CLI review sessions, use `cline --cwd .worktrees/<review-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<review-slug>/` when prompted for a folder path.
+- If review is run as a Cline Kanban card, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
+- If a Kanban review card creates a task worktree, move the card to trash/delete when review is
+  complete so cleanup runs.
 - Do not modify source files while reviewing.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-skill-executable-card.md
+++ b/.agents/skills/plaited-development/references/kanban-skill-executable-card.md
@@ -23,12 +23,17 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Run in an isolated git worktree.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
 - Keep skill execution changes isolated from unrelated cards.
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-skill-pattern-card.md
+++ b/.agents/skills/plaited-development/references/kanban-skill-pattern-card.md
@@ -23,11 +23,16 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Run in an isolated git worktree.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/.agents/skills/plaited-development/references/kanban-tooling-card.md
+++ b/.agents/skills/plaited-development/references/kanban-tooling-card.md
@@ -29,12 +29,17 @@ Required Repo Instructions
 
 Worktree Expectations
 - Start from a fresh branch/worktree based on `origin/dev`.
-- Run in an isolated git worktree.
+- For manual worktree creation, prefer `.worktrees/<card-slug>/`.
+- For manual Cline CLI runs, use `cline --cwd .worktrees/<card-slug>`.
+- In Cline Worktrees UI, choose `.worktrees/<card-slug>/` when prompted for a folder path.
+- If running through Cline Kanban, use the tool-managed task worktree path under
+  `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`.
 - Target PRs at `dev` unless explicitly scoped to release/promotion work.
 - Expect squash merge into `dev` for normal card work.
 - Pull/sync `dev` with fast-forward only (`git fetch origin dev` then `git merge --ff-only origin/dev`).
 - Keep tooling changes isolated from feature cards.
 - After merge, trash/delete the card worktree.
+- For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
 Validation Expectations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,12 @@ Do not rely on long-running opaque subagent state as the only record for large f
 **File history** — `git log --oneline -- <path>` to understand why.
 **Branch scope** — `git diff main...HEAD --stat` for current changes.
 **History over stale prose** — code + git history wins. Update the doc.
+**Agent worktrees** — create new manual task worktrees under `.worktrees/<task-slug>/` from
+`origin/dev` unless a task explicitly says otherwise. Use that path with Cline CLI via
+`cline --cwd .worktrees/<task-slug>` or choose it in Cline Worktrees UI when prompted. Cline
+Kanban card worktrees are tool-managed and currently live under `~/.cline/worktrees/...`; do not
+assume Kanban can be configured to use `.worktrees/`. Existing external worktrees may finish in
+place. Worktrees are disposable after merge.
 
 ## Git Commits
 


### PR DESCRIPTION
## Context

- Standardize manual agent worktree placement under repo-local `.worktrees/<task-slug>/` for docs/policy guidance.
- Preserve current Cline/Kanban behavior accurately: Kanban task worktrees are tool-managed under
  `~/.cline/worktrees/...` with no documented worktree-root override in current CLI help.
- Scope is policy/docs/skill-template text only.

## Summary

- Added a concise `Agent worktrees` baseline rule to `AGENTS.md`.
- Updated `.agents/skills/plaited-development/SKILL.md` Development Lane/Kanban policy text to:
  - prefer manual `.worktrees/<slug>/` placement from fresh `origin/dev`
  - use `cline --cwd .worktrees/<slug>` (and Cline Worktrees UI folder-path selection) for manual flows
  - state Kanban task worktrees are tool-managed under `~/.cline/worktrees/<task-id>/<workspace-folder-label>/`
  - avoid presenting `CLINE_DIR` as a Kanban task-worktree root solution
  - keep branch strategy unchanged (`dev` PR target, squash into `dev`, `main` release, no reset/rebase/force-push of `dev`)
- Normalized Worktree Expectations across all current Kanban card templates.
- Kept review-card worktree guidance lighter: no worktree required for read-only review, but manual/Kanban path guidance is explicit when used.
- No runtime source code changed.
- No GitHub workflow files changed.
- `.worktrees/` was already ignored in `.gitignore` and was not modified.

## Changed Files

- `AGENTS.md`
- `.agents/skills/plaited-development/SKILL.md`
- `.agents/skills/plaited-development/references/kanban-code-card.md`
- `.agents/skills/plaited-development/references/kanban-skill-pattern-card.md`
- `.agents/skills/plaited-development/references/kanban-skill-executable-card.md`
- `.agents/skills/plaited-development/references/kanban-tooling-card.md`
- `.agents/skills/plaited-development/references/kanban-review-card.md`
- `.agents/skills/plaited-development/references/kanban-cleanup-card.md`
- `.agents/skills/plaited-development/references/kanban-eval-card.md`
- `.agents/skills/plaited-development/references/kanban-autoresearch-card.md`

## Validation

- Targeted tests: skipped (docs/policy/template-only slice; no executable/runtime changes)
- `bun --bun tsc --noEmit`: skipped (no TypeScript/executable files touched)
- `rg -n "\\.worktrees|Agent worktrees|manual.*worktree|cline --cwd|Cline Worktrees UI|Kanban.*tool-managed|~/.cline/worktrees|origin/dev|trash/delete|squash-merged|CLINE_DIR" AGENTS.md .agents/skills/plaited-development`
  - confirms `.worktrees`, `cline --cwd`, `Cline Worktrees UI`, `~/.cline/worktrees`, and squash/trash guidance in policy/templates
  - confirms `CLINE_DIR` is only referenced as a non-solution warning
- `find .agents/skills/plaited-development/references -maxdepth 1 -type f | sort`
  - confirms all expected Kanban template files are present
- `bun run kanban:help`
- `bun run kanban -- task create --help`
- `bun run kanban -- task start --help`
  - no documented worktree root/path override options exposed
- Inspected installed `kanban@0.1.60` distribution under `node_modules/kanban/dist/cli.js`:
  - worktree constants/paths resolve under `homedir(), ".cline", "worktrees"`
  - task worktree path composes `<task-id>/<workspace-folder-label>`
- `bunx biome check --write AGENTS.md .agents/skills/plaited-development/SKILL.md .agents/skills/plaited-development/references/*.md`
  - Biome reports these paths are ignored by repo config (no files processed)

## Known Failures / Drift

- Biome markdown formatting command reported all provided paths are ignored by current Biome config.
- No runtime/test drift introduced by this PR.

## Review Notes / Residual Risks

- This is prose/policy normalization only; enforcement is still process-based, not tool-enforced.
- Kanban behavior statements are accurate for current checked surfaces (`kanban --help` and installed `kanban@0.1.60`) and may require future updates if Kanban exposes supported worktree-root config.
- Existing external/sibling worktrees are intentionally allowed to finish in place.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
