### PR TITLE
fix(cli): preserve markdown parsing while avoiding redos

### DIFF
--- a/src/cli/utils/markdown.ts
+++ b/src/cli/utils/markdown.ts
@@ -2,7 +2,68 @@ import { normalize } from 'node:path'
 import { YAML } from 'bun'
 import type * as z from 'zod'
 
-const frontmatterRegex = /^---\s*[\r\n]([\s\S]*?)[\r\n]---\s*/
+type ParsedFrontmatterBlock = {
+  frontmatter: string
+  bodyStartIndex: number
+}
+
+const isLineBreakCharacter = (character: string | undefined): boolean => character === '\n' || character === '\r'
+
+const isWhitespaceCharacter = (character: string): boolean => {
+  const charCode = character.charCodeAt(0)
+  if (
+    charCode === 0x20 ||
+    charCode === 0x09 ||
+    charCode === 0x0a ||
+    charCode === 0x0b ||
+    charCode === 0x0c ||
+    charCode === 0x0d
+  ) {
+    return true
+  }
+
+  return character.trim().length === 0
+}
+
+const isWhitespaceAt = (value: string, index: number): boolean => {
+  const character = value[index]
+  return character !== undefined && isWhitespaceCharacter(character)
+}
+
+const parseFrontmatterBlock = (markdown: string): ParsedFrontmatterBlock | null => {
+  if (!markdown.startsWith('---')) return null
+
+  let openingDelimiterEndIndex = 3
+  while (openingDelimiterEndIndex < markdown.length && isWhitespaceAt(markdown, openingDelimiterEndIndex)) {
+    openingDelimiterEndIndex += 1
+  }
+
+  if (openingDelimiterEndIndex === 3 || !isLineBreakCharacter(markdown[openingDelimiterEndIndex - 1])) {
+    return null
+  }
+
+  const frontmatterStartIndex = openingDelimiterEndIndex
+  let frontmatterEndIndex = -1
+
+  for (let index = frontmatterStartIndex; index < markdown.length - 3; index++) {
+    if (!isLineBreakCharacter(markdown[index])) continue
+    if (!markdown.startsWith('---', index + 1)) continue
+    frontmatterEndIndex = index
+    break
+  }
+
+  if (frontmatterEndIndex === -1) return null
+
+  let bodyStartIndex = frontmatterEndIndex + 4
+  while (bodyStartIndex < markdown.length && isWhitespaceAt(markdown, bodyStartIndex)) {
+    bodyStartIndex += 1
+  }
+
+  return {
+    frontmatter: markdown.slice(frontmatterStartIndex, frontmatterEndIndex),
+    bodyStartIndex,
+  }
+}
 
 /**
  * Consumes an `HTMLRewriter` result so link extraction side effects are applied.
@@ -43,13 +104,13 @@ export const parseMarkdownWithFrontmatter = <TSchema extends z.ZodType>(
     requireBody?: boolean
   },
 ): { frontmatter: z.infer<TSchema>; body: string } => {
-  const match = markdown.match(frontmatterRegex)
-  const frontmatter = match?.[1]
+  const parsedFrontmatterBlock = parseFrontmatterBlock(markdown)
+  const frontmatter = parsedFrontmatterBlock?.frontmatter
   if (!frontmatter) {
     throw new Error('Missing YAML frontmatter')
   }
 
-  const body = markdown.slice(match[0].length).trim()
+  const body = markdown.slice(parsedFrontmatterBlock.bodyStartIndex).trim()
   if (options?.requireBody !== false && !body) {
     throw new Error('Markdown body must not be empty')
   }

--- a/src/cli/utils/markdown.ts
+++ b/src/cli/utils/markdown.ts
@@ -33,16 +33,20 @@ const isWhitespaceAt = (value: string, index: number): boolean => {
 const parseFrontmatterBlock = (markdown: string): ParsedFrontmatterBlock | null => {
   if (!markdown.startsWith('---')) return null
 
-  let openingDelimiterEndIndex = 3
-  while (openingDelimiterEndIndex < markdown.length && isWhitespaceAt(markdown, openingDelimiterEndIndex)) {
-    openingDelimiterEndIndex += 1
+  let openingDelimiterScanIndex = 3
+  let lastOpeningLineBreakIndex = -1
+  while (openingDelimiterScanIndex < markdown.length && isWhitespaceAt(markdown, openingDelimiterScanIndex)) {
+    if (isLineBreakCharacter(markdown[openingDelimiterScanIndex])) {
+      lastOpeningLineBreakIndex = openingDelimiterScanIndex
+    }
+    openingDelimiterScanIndex += 1
   }
 
-  if (openingDelimiterEndIndex === 3 || !isLineBreakCharacter(markdown[openingDelimiterEndIndex - 1])) {
+  if (lastOpeningLineBreakIndex === -1) {
     return null
   }
 
-  const frontmatterStartIndex = openingDelimiterEndIndex
+  const frontmatterStartIndex = lastOpeningLineBreakIndex + 1
   let frontmatterEndIndex = -1
 
   for (let index = frontmatterStartIndex; index < markdown.length - 3; index++) {

--- a/src/cli/utils/tests/markdown.spec.ts
+++ b/src/cli/utils/tests/markdown.spec.ts
@@ -69,6 +69,20 @@ Body content.
     expect(parsed.body).toBe('# Heading\n\nBody content.')
   })
 
+  test('preserves leading indentation after opening delimiter before YAML parsing', () => {
+    expect(() =>
+      parseMarkdownWithFrontmatter(
+        `---
+ name: test-skill
+description: A test skill
+---
+Body content.
+`,
+        TestFrontmatterSchema,
+      ),
+    ).toThrow('YAML Parse error')
+  })
+
   test('throws when frontmatter is missing', () => {
     expect(() => parseMarkdownWithFrontmatter('# No frontmatter', TestFrontmatterSchema)).toThrow(
       'Missing YAML frontmatter',

--- a/src/cli/utils/tests/markdown.spec.ts
+++ b/src/cli/utils/tests/markdown.spec.ts
@@ -54,6 +54,21 @@ description: A test skill
     expect(parsed.body).toBe('')
   })
 
+  test('preserves legacy parsing when closing delimiter is followed by body text on the same line', () => {
+    const parsed = parseMarkdownWithFrontmatter(
+      `---
+name: test-skill
+description: A test skill
+---# Heading
+
+Body content.
+`,
+      TestFrontmatterSchema,
+    )
+
+    expect(parsed.body).toBe('# Heading\n\nBody content.')
+  })
+
   test('throws when frontmatter is missing', () => {
     expect(() => parseMarkdownWithFrontmatter('# No frontmatter', TestFrontmatterSchema)).toThrow(
       'Missing YAML frontmatter',
@@ -70,6 +85,13 @@ description: A test skill
         TestFrontmatterSchema,
       ),
     ).toThrow('Markdown body must not be empty')
+  })
+
+  test('throws on large malformed near-delimiter input without hanging', () => {
+    const repeatedNearDelimiterWhitespace = '\n '.repeat(20_000)
+    const markdown = `---${repeatedNearDelimiterWhitespace}`
+
+    expect(() => parseMarkdownWithFrontmatter(markdown, TestFrontmatterSchema)).toThrow('Missing YAML frontmatter')
   })
 })
 


### PR DESCRIPTION
## Context

- Follow-up for CodeQL alert #14 (`js/polynomial-redos`, high) in `src/cli/utils/markdown.ts`.
- This replaces PR #237's rejected approach. PR #237 was not merged because it introduced a
  markdown/frontmatter compatibility regression.
- Scope is intentionally narrow to:
  - `src/cli/utils/markdown.ts`
  - `src/cli/utils/tests/markdown.spec.ts`

## Summary

- Replaced the vulnerable frontmatter regex with a linear, regex-free scanner for opening and
  closing delimiters.
- Preserved existing parser behavior from `origin/dev`, including legacy acceptance where closing
  `---` may be immediately followed by body content on the same line (for example `---# Heading`).
- Added regression tests for compatibility and large malformed near-delimiter input.
- No workflow/release-readiness changes were made.

## Changed Files

- `src/cli/utils/markdown.ts`
  - Added `parseFrontmatterBlock` scanner and whitespace/line-break helpers.
  - Kept existing errors and YAML + schema validation flow.
- `src/cli/utils/tests/markdown.spec.ts`
  - Added compatibility regression test for inline body after closing delimiter.
  - Added adversarial large malformed near-delimiter test.

## Validation

- Targeted tests:
  - `bun test src/cli/utils/tests/markdown.spec.ts` (pass, 16/16)
  - `bun test src/cli/utils/tests/markdown.spec.ts` after Biome (pass, 16/16)
- `bun --bun tsc --noEmit`: pass
- `bunx biome check --write src/cli/utils/markdown.ts src/cli/utils/tests/markdown.spec.ts`: pass
- Quick bounded smoke check:
  - malformed near-delimiter input throws `Missing YAML frontmatter` in ~0.71ms locally

## Known Failures / Drift

- None observed locally for this slice.
- CodeQL alert clearance depends on GitHub rescan after branch analysis.

## Review Notes / Residual Risks

- Parser behavior is intentionally compatibility-preserving rather than syntax-tightening.
- This PR does not attempt broader markdown parser redesign.
- Expected outcome: CodeQL `js/polynomial-redos` should clear for this file after GitHub rescans.
  If CodeQL still flags it, that will require follow-up based on scan details.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
