### PR TITLE
docs(skills): document PR branch freshness policy

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -49,6 +49,19 @@ git merge --ff-only origin/dev
   land through PRs into `dev`.
 - Direct pushes to `dev` should be explicit integration/admin operations only.
 
+## PR Branch Freshness
+
+- The authoring agent owns keeping its PR branch current with fresh `origin/dev`.
+- Before final handoff, review request, or merge request, update the PR branch from fresh
+  `origin/dev`.
+- Prefer a normal merge/update-branch flow over rebase/force-push for shared PR branches.
+- Do not reset, rebase, or force-push `dev`.
+- If updating from `origin/dev` creates conflicts, the owning agent resolves them in its worktree
+  and reruns affected validation.
+- Do not add a GitHub workflow that mutates active PR branches unless explicitly requested.
+- GitHub should report mergeability/check status; active PR branch mutation belongs to the owning
+  local agent for now.
+
 ## 4. Development Lane
 
 - Cline Kanban is the primary local orchestration lane for Plaited agent work.

--- a/.agents/skills/plaited-development/references/kanban-autoresearch-card.md
+++ b/.agents/skills/plaited-development/references/kanban-autoresearch-card.md
@@ -69,6 +69,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Run `biome check --write <affected files>` when applicable.
 - Run lane-appropriate targeted checks for the mutated asset surface.

--- a/.agents/skills/plaited-development/references/kanban-cleanup-card.md
+++ b/.agents/skills/plaited-development/references/kanban-cleanup-card.md
@@ -38,6 +38,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Validation follows the declared cleanup lane (`code`, `skill-pattern`,
   `skill-executable`, or `tooling`).

--- a/.agents/skills/plaited-development/references/kanban-code-card.md
+++ b/.agents/skills/plaited-development/references/kanban-code-card.md
@@ -37,6 +37,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Run targeted Bun tests for the changed surface.
 - Run `biome check --write <affected files>`.

--- a/.agents/skills/plaited-development/references/kanban-eval-card.md
+++ b/.agents/skills/plaited-development/references/kanban-eval-card.md
@@ -55,6 +55,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Keep task corpus and rubric stable across baseline/variant runs.
 - Use consistent findings-first criteria across compared runs.

--- a/.agents/skills/plaited-development/references/kanban-review-card.md
+++ b/.agents/skills/plaited-development/references/kanban-review-card.md
@@ -31,6 +31,11 @@ Worktree Expectations
   complete so cleanup runs.
 - Do not modify source files while reviewing.
 
+Review freshness
+- Check whether the PR branch is current/mergeable against `dev`.
+- If stale or conflicted, request the owning agent update from fresh `origin/dev`.
+- Do not recommend workflow-based auto-updates unless explicitly requested.
+
 Validation Expectations
 - Verify validation claims against changed surface.
 - Verify normal card PRs target `dev`.

--- a/.agents/skills/plaited-development/references/kanban-skill-executable-card.md
+++ b/.agents/skills/plaited-development/references/kanban-skill-executable-card.md
@@ -36,6 +36,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Run relevant skill tests and/or smoke commands for touched executable surfaces.
 - Run `biome check --write <affected files>`.

--- a/.agents/skills/plaited-development/references/kanban-skill-pattern-card.md
+++ b/.agents/skills/plaited-development/references/kanban-skill-pattern-card.md
@@ -35,6 +35,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Use search validation with `rg` checks for renamed/removed references and policy consistency.
 - Run `biome check --write <affected files>` when applicable.

--- a/.agents/skills/plaited-development/references/kanban-tooling-card.md
+++ b/.agents/skills/plaited-development/references/kanban-tooling-card.md
@@ -48,6 +48,13 @@ Worktree Expectations
 - For Kanban task worktrees, rely on card trash/delete cleanup.
 - Do not continue work on a squash-merged branch.
 
+Before final handoff
+- Fetch `origin/dev`.
+- Update this PR branch from `origin/dev` using a normal merge/update-branch flow.
+- Resolve conflicts in this worktree if they occur.
+- Rerun affected validation after the update.
+- Do not rebase/force-push shared PR branches unless explicitly instructed.
+
 Validation Expectations
 - Run `biome check --write <affected files>`.
 - Run `format-package --write package.json` if package metadata changes.


### PR DESCRIPTION
## Context

- We are formalizing policy that active PR branch freshness is owned by the local Cline/Kanban
  authoring agent, not by GitHub branch-mutating automation.
- The owning agent has the worktree context, conflict surface, and validation responsibility.

## Summary

- Added a new `PR Branch Freshness` section to `.agents/skills/plaited-development/SKILL.md`.
- Added a concise `Before final handoff` checkpoint to all work-producing Kanban card templates.
- Added a `Review freshness` checkpoint to the review card template.
- This is policy/card-template guidance only.
- No runtime source code changed.
- No GitHub workflow was added.
- No branch-mutating automation was added.
- No GitHub ruleset/merge-queue setting changed.

## Changed Files

- `.agents/skills/plaited-development/SKILL.md`
- `.agents/skills/plaited-development/references/kanban-code-card.md`
- `.agents/skills/plaited-development/references/kanban-tooling-card.md`
- `.agents/skills/plaited-development/references/kanban-skill-pattern-card.md`
- `.agents/skills/plaited-development/references/kanban-skill-executable-card.md`
- `.agents/skills/plaited-development/references/kanban-eval-card.md`
- `.agents/skills/plaited-development/references/kanban-autoresearch-card.md`
- `.agents/skills/plaited-development/references/kanban-cleanup-card.md`
- `.agents/skills/plaited-development/references/kanban-review-card.md`

## Validation

- Targeted tests: skipped; prose/card-template-only policy change.
- `bun --bun tsc --noEmit`: skipped; no TypeScript/runtime/executable surface changed.
- `rg -n "PR Branch Freshness|authoring agent owns|origin/dev|normal merge/update-branch|rebase|force-push|GitHub workflow.*mutates|Before final handoff|Review freshness|current/mergeable" .agents/skills/plaited-development`
  - Pass; policy/checkpoint terms present in skill + templates.
- `bunx biome check --write .agents/skills/plaited-development/SKILL.md .agents/skills/plaited-development/references/*.md`
  - Biome processed 0 files; these `.agents/...` paths are ignored by current config.
- `git diff --check`
  - Pass; no whitespace/errors.

## Known Failures / Drift

- No executable/test drift introduced.
- Biome currently ignores `.agents/skills/plaited-development/*` in this repo config.

## Review Notes / Residual Risks

- Policy now explicitly keeps active PR branch mutation local to the owning agent.
- Residual risk is process adherence by future authoring agents, not runtime behavior.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
