### PR TITLE
fix(workflows): use release readiness security token

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -24,6 +24,9 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       RELEASE_READINESS_GITHUB_TOKEN: ${{ secrets.RELEASE_READINESS_GITHUB_TOKEN }}
       GITHUB_REPO: ${{ github.repository }}
+      WORKFLOW_REF_NAME: ${{ github.ref_name }}
+      WORKFLOW_SHA: ${{ github.sha }}
+      WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       TITLE: "Release readiness: dev -> main"
 
     steps:
@@ -63,6 +66,11 @@ jobs:
           body_file="${work_dir}/issue-body.md"
           security_token_source="github-token"
           security_gh_token="${GH_TOKEN}"
+          branch_of_record="false"
+
+          if [ "${WORKFLOW_REF_NAME}" = "dev" ]; then
+            branch_of_record="true"
+          fi
 
           if [ -n "${RELEASE_READINESS_GITHUB_TOKEN:-}" ]; then
             security_token_source="release-readiness-secret"
@@ -346,6 +354,10 @@ jobs:
           ## Release Readiness Snapshot
 
           - Generated at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          - Workflow ref: \`${WORKFLOW_REF_NAME}\`
+          - Workflow SHA: \`${WORKFLOW_SHA}\`
+          - Workflow run: \`${WORKFLOW_RUN_URL}\`
+          - Branch-of-record: \`${branch_of_record}\`
           - Base comparison: \`main..dev\`
           - Commit count ahead of main: ${commit_count}
           - Changed file count ahead of main: ${changed_file_count}
@@ -441,21 +453,30 @@ jobs:
           EOF
           sed -i 's/^          //' "${body_file}"
 
-          existing_issue_number="$(
-            gh issue list --repo "${GITHUB_REPO}" --state open --limit 200 --json number,title \
-              | jq -r --arg title "${TITLE}" 'map(select(.title == $title)) | first | .number // empty'
-          )"
+          if [ "${branch_of_record}" = "true" ]; then
+            existing_issue_number="$(
+              gh issue list --repo "${GITHUB_REPO}" --state open --limit 200 --json number,title \
+                | jq -r --arg title "${TITLE}" 'map(select(.title == $title)) | first | .number // empty'
+            )"
 
-          if [ -n "${existing_issue_number}" ]; then
-            gh issue edit "${existing_issue_number}" \
-              --repo "${GITHUB_REPO}" \
-              --title "${TITLE}" \
-              --body-file "${body_file}"
-            echo "Updated issue #${existing_issue_number}"
+            if [ -n "${existing_issue_number}" ]; then
+              gh issue edit "${existing_issue_number}" \
+                --repo "${GITHUB_REPO}" \
+                --title "${TITLE}" \
+                --body-file "${body_file}"
+              echo "Updated issue #${existing_issue_number}"
+            else
+              gh issue create \
+                --repo "${GITHUB_REPO}" \
+                --title "${TITLE}" \
+                --body-file "${body_file}"
+              echo "Created issue: ${TITLE}"
+            fi
           else
-            gh issue create \
-              --repo "${GITHUB_REPO}" \
-              --title "${TITLE}" \
-              --body-file "${body_file}"
-            echo "Created issue: ${TITLE}"
+            {
+              echo "## Release Readiness Preview"
+              echo
+              cat "${body_file}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "Preview run from ${WORKFLOW_REF_NAME}; canonical release-readiness issue was not updated."
           fi

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 30
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_READINESS_GITHUB_TOKEN: ${{ secrets.RELEASE_READINESS_GITHUB_TOKEN }}
       GITHUB_REPO: ${{ github.repository }}
       TITLE: "Release readiness: dev -> main"
 
@@ -60,6 +61,13 @@ jobs:
           default_setup_err_file="${work_dir}/codeql-default-setup.err"
           default_setup_collection_status="available"
           body_file="${work_dir}/issue-body.md"
+          security_token_source="github-token"
+          security_gh_token="${GH_TOKEN}"
+
+          if [ -n "${RELEASE_READINESS_GITHUB_TOKEN:-}" ]; then
+            security_token_source="release-readiness-secret"
+            security_gh_token="${RELEASE_READINESS_GITHUB_TOKEN}"
+          fi
 
           git log --oneline origin/main..origin/dev > "${log_file}"
           git diff --stat origin/main..origin/dev > "${diff_stat_file}"
@@ -89,28 +97,32 @@ jobs:
             echo "${reason}"
           }
 
-          if gh api "repos/${GITHUB_REPO}/code-scanning/alerts?state=open&per_page=100" > "${codeql_file}" 2> "${codeql_err_file}"; then
+          security_api() {
+            GH_TOKEN="${security_gh_token}" gh api "$@"
+          }
+
+          if security_api "repos/${GITHUB_REPO}/code-scanning/alerts?state=open&per_page=100" > "${codeql_file}" 2> "${codeql_err_file}"; then
             codeql_collection_status="available"
           else
             codeql_collection_status="unavailable ($(format_unavailable_reason "${codeql_err_file}"))"
             echo '[]' > "${codeql_file}"
           fi
 
-          if gh api "repos/${GITHUB_REPO}/dependabot/alerts?state=open&per_page=100" > "${dependabot_file}" 2> "${dependabot_err_file}"; then
+          if security_api "repos/${GITHUB_REPO}/dependabot/alerts?state=open&per_page=100" > "${dependabot_file}" 2> "${dependabot_err_file}"; then
             dependabot_collection_status="available"
           else
             dependabot_collection_status="unavailable ($(format_unavailable_reason "${dependabot_err_file}"))"
             echo '[]' > "${dependabot_file}"
           fi
 
-          if gh api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_file}" 2> "${secret_err_file}"; then
+          if security_api "repos/${GITHUB_REPO}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true" > "${secret_file}" 2> "${secret_err_file}"; then
             secret_scanning_collection_status="available"
           else
             secret_scanning_collection_status="unavailable ($(format_unavailable_reason "${secret_err_file}"))"
             echo '[]' > "${secret_file}"
           fi
 
-          if gh api "repos/${GITHUB_REPO}/code-scanning/default-setup" > "${default_setup_file}" 2> "${default_setup_err_file}"; then
+          if security_api "repos/${GITHUB_REPO}/code-scanning/default-setup" > "${default_setup_file}" 2> "${default_setup_err_file}"; then
             default_setup_collection_status="available"
           else
             default_setup_collection_status="unavailable ($(format_unavailable_reason "${default_setup_err_file}"))"
@@ -328,7 +340,7 @@ jobs:
 
           required_human_checks=$'- Confirm release scope and version bump from commit intent.\n- Confirm no undisclosed security exceptions are being accepted.\n- Confirm validation evidence for changed runtime/package surfaces.\n- Confirm post-release main -> dev sync plan (merge commit, no reset/rebase/force-push).'
 
-          validation_summary="Dev checks_collection_status=${checks_collection_status}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_scanning_collection_status}; default_setup_collection_status=${default_setup_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}."
+          validation_summary="Dev checks_collection_status=${checks_collection_status}; security_token_source=${security_token_source}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_scanning_collection_status}; default_setup_collection_status=${default_setup_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}."
 
           cat > "${body_file}" <<EOF
           ## Release Readiness Snapshot
@@ -357,6 +369,7 @@ jobs:
           validation_summary: ${validation_summary}
           main_to_dev_sync_required: ${main_to_dev_sync_required}
           security_summary:
+            security_token_source: ${security_token_source}
             codeql_collection_status: ${codeql_collection_status}
             dependabot_collection_status: ${dependabot_collection_status}
             secret_scanning_collection_status: ${secret_scanning_collection_status}
@@ -381,6 +394,7 @@ jobs:
 
           ## Deterministic Security Summary
 
+          - Security token source: \`${security_token_source}\`
           - CodeQL collection status: \`${codeql_collection_status}\`
           - Dependabot collection status: \`${dependabot_collection_status}\`
           - Secret-scanning collection status: \`${secret_scanning_collection_status}\`

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -477,6 +477,6 @@ jobs:
               echo "## Release Readiness Preview"
               echo
               cat "${body_file}"
-            } >> "${GITHUB_STEP_SUMMARY}"
+            } | tee -a "${GITHUB_STEP_SUMMARY}"
             echo "Preview run from ${WORKFLOW_REF_NAME}; canonical release-readiness issue was not updated."
           fi


### PR DESCRIPTION
## Context

- Release-readiness security endpoints were returning 403 with the default `GITHUB_TOKEN`, leaving
  Dependabot, secret-scanning, and CodeQL default-setup facts unavailable.
- The initial token slice fixed endpoint access but still allowed PR-branch runs to mutate the
  canonical release-readiness issue (`Release readiness: dev -> main`).
- This update keeps the token behavior and adds branch-of-record gating plus workflow provenance so
  non-dev runs are preview-only.

## Summary

- Added optional workflow env wiring for `RELEASE_READINESS_GITHUB_TOKEN` (security API reads only).
- Added `security_token_source` selection and `security_api()` helper for security endpoints only.
- Added workflow provenance env vars: `WORKFLOW_REF_NAME`, `WORKFLOW_SHA`, `WORKFLOW_RUN_URL`.
- Added `branch_of_record` (`true` only when `github.ref_name == dev`).
- Added provenance fields to the generated packet:
  - workflow ref
  - workflow SHA
  - workflow run URL
  - branch-of-record flag
- Guarded issue mutation:
  - `branch_of_record=true`: keep existing issue create/edit behavior
  - `branch_of_record=false`: do not mutate issues; emit preview to `GITHUB_STEP_SUMMARY`
- Non-dev preview is also emitted to logs via `tee -a "$GITHUB_STEP_SUMMARY"` for deterministic
  validation.
- Kept `hide_secret=true` and conservative unavailable=>P1 fallback behavior.
- No runtime code changed.
- No branch-mutating automation added.
- No GitHub rulesets changed.
- No direct OpenRouter path added.
- Token values are never printed or included in issue output.

## Changed Files

- `.github/workflows/release-readiness.yml`

## Validation

- Targeted tests: skipped (workflow/YAML-only change; no runtime code touched).
- `bun --bun tsc --noEmit`: skipped per card instruction (do not run TypeScript/runtime tests for
  this YAML-only workflow change).
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-readiness.yml"); puts "yaml ok"'`
  - pass (`yaml ok`)
- `rg -n "WORKFLOW_REF_NAME|WORKFLOW_SHA|WORKFLOW_RUN_URL|branch_of_record|GITHUB_STEP_SUMMARY|gh issue create|gh issue edit|RELEASE_READINESS_GITHUB_TOKEN|security_api|hide_secret=true" .github/workflows/release-readiness.yml`
  - confirms provenance env vars, branch guard, summary preview path, token wiring, security helper,
    and preserved `hide_secret=true`
- Manual dispatch from PR branch:
  - `gh workflow run release-readiness.yml --repo plaited/plaited --ref agent/release-readiness-security-token`
  - run URL: `https://github.com/plaited/plaited/actions/runs/24430076478`
  - result: `success`
  - preview evidence in run log:
    - `## Release Readiness Preview`
    - `Workflow ref: agent/release-readiness-security-token`
    - `Branch-of-record: false`
    - `Preview run from agent/release-readiness-security-token; canonical release-readiness issue was not updated.`
  - security facts still available in preview packet:
    - `security_token_source=release-readiness-secret`
    - `codeql_collection_status=available`
    - `dependabot_collection_status=available`
    - `secret_scanning_collection_status=available`
    - `default_setup_collection_status=available`
  - canonical issue non-mutation proof:
    - `#241 updatedAt` before run: `2026-04-15T00:31:15Z`
    - `#241 updatedAt` after run: `2026-04-15T00:31:15Z`

## Known Failures / Drift

- None observed for this change slice.

## Review Notes / Residual Risks

- If `RELEASE_READINESS_GITHUB_TOKEN` is missing or under-scoped, security facts remain
  best-effort/unavailable and still block readiness as P1 (existing conservative behavior).
- PR-branch runs are now preview-only and no longer mutate canonical `#241`.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
