### PR TITLE
feat(workflows): add human-triggered release PR workflow

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -220,13 +220,17 @@ git merge --ff-only origin/dev
 ## 10. Release / Promotion Strategy
 
 - Land reviewed agent branches through `dev` before any promotion work.
-- Release-readiness is issue-first for now:
+- Release-readiness remains issue-first:
   - scheduled/manual agent review covers `main..dev`
   - opens/updates a release-readiness issue
-  - human decides whether to open `dev -> main` PR
-- Later, a workflow may open/update the release PR automatically when readiness packets are
-  trustworthy.
+- Release PR creation/update is handled by the manual `Open Release PR` workflow.
+- The `Open Release PR` workflow must only proceed when the release-readiness issue is current for
+  `origin/dev`, reports branch-of-record `true`, and reports `ready: true`.
+- The `Open Release PR` workflow opens/updates a `dev -> main` PR only; it does not mutate
+  branches.
 - Human approval remains required for `dev -> main`.
+- The `Open Release PR` workflow does not auto-merge.
+- The `Open Release PR` workflow does not publish.
 - Publish remains human-gated or release-environment-gated.
 - `dev -> main` release PRs should squash-merge.
 - After squash release, `main -> dev` sync merge commit is required.
@@ -302,8 +306,12 @@ security_summary:
    - opens/updates a release-readiness issue
    - does not mutate branches
 2. Open-release-PR workflow
-   - human-triggered at first
+   - implemented/manual via `workflow_dispatch`
+   - validates the release-readiness issue is current for `origin/dev`, branch-of-record `true`,
+     and `ready: true`
    - opens/updates `dev -> main` PR
+   - does not auto-merge
+   - does not publish
    - includes readiness packet, release notes draft, validation summary, and `P0`/`P1` checklist
 3. Post-release sync workflow
    - runs after squash merge to `main` or by manual dispatch

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,354 @@
+name: Open Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate readiness and render the would-be PR body without creating/updating a PR"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: open-release-pr
+  cancel-in-progress: true
+
+jobs:
+  open-release-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_REPO: ${{ github.repository }}
+      READINESS_TITLE: "Release readiness: dev -> main"
+      RELEASE_PR_TITLE: "Release: dev -> main"
+      RELEASE_PR_BASE: "main"
+      RELEASE_PR_HEAD: "dev"
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release-readiness and open/update release PR
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          fail_with() {
+            echo "$1" >&2
+            exit 1
+          }
+
+          require_fixed() {
+            local required_line="$1"
+            local description="$2"
+            if ! grep -Fq -- "$required_line" "${issue_body_file}"; then
+              fail_with "Release-readiness issue #${readiness_issue_number} is missing required field: ${description}."
+            fi
+          }
+
+          require_regex() {
+            local pattern="$1"
+            local description="$2"
+            if ! grep -Eq -- "$pattern" "${issue_body_file}"; then
+              fail_with "Release-readiness issue #${readiness_issue_number} is missing required field: ${description}."
+            fi
+          }
+
+          extract_section() {
+            local heading="$1"
+            local output_file="$2"
+            awk -v target_heading="## ${heading}" '
+              $0 == target_heading { in_section = 1; print; next }
+              in_section && /^## / { exit }
+              in_section { print }
+            ' "${issue_body_file}" > "${output_file}"
+
+            if [ ! -s "${output_file}" ]; then
+              fail_with "Release-readiness issue #${readiness_issue_number} is missing required section: ${heading}."
+            fi
+          }
+
+          append_packet_section() {
+            local heading="$1"
+            local section_file="$2"
+            {
+              echo "### ${heading}"
+              awk 'NR > 1 { print }' "${section_file}"
+              echo
+            } >> "${pr_body_file}"
+          }
+
+          work_dir="${RUNNER_TEMP}/open-release-pr"
+          mkdir -p "${work_dir}"
+
+          issue_body_file="${work_dir}/readiness-issue-body.md"
+          pr_body_file="${work_dir}/release-pr-body.md"
+          deterministic_check_file="${work_dir}/deterministic-check-summary.md"
+          deterministic_security_file="${work_dir}/deterministic-security-summary.md"
+          included_prs_file="${work_dir}/included-prs.md"
+          changed_surfaces_raw_file="${work_dir}/changed-surfaces.raw.md"
+          changed_surfaces_file="${work_dir}/changed-surfaces.md"
+          p0_p1_checklist_file="${work_dir}/p0-p1-checklist.md"
+          human_decision_file="${work_dir}/human-decision.md"
+          label_notes_file="${work_dir}/label-notes.md"
+          : > "${label_notes_file}"
+
+          dry_run="${DRY_RUN:-true}"
+          if [ "${dry_run}" != "true" ] && [ "${dry_run}" != "false" ]; then
+            fail_with "Invalid dry_run input '${dry_run}'. Expected 'true' or 'false'."
+          fi
+
+          git fetch --no-tags origin main dev
+          dev_sha="$(git rev-parse origin/dev)"
+
+          readiness_matches_json="$(
+            gh issue list \
+              --repo "${GITHUB_REPO}" \
+              --state open \
+              --limit 200 \
+              --json number,title,url \
+              | jq --arg title "${READINESS_TITLE}" '[.[] | select(.title == $title)]'
+          )"
+          readiness_count="$(jq 'length' <<< "${readiness_matches_json}")"
+
+          if [ "${readiness_count}" -eq 0 ]; then
+            fail_with "No open issue found with exact title '${READINESS_TITLE}'."
+          fi
+
+          if [ "${readiness_count}" -gt 1 ]; then
+            duplicate_numbers="$(jq -r '.[].number' <<< "${readiness_matches_json}" | paste -sd "," -)"
+            fail_with "Expected exactly one open '${READINESS_TITLE}' issue but found ${readiness_count}: #${duplicate_numbers}."
+          fi
+
+          readiness_issue_number="$(jq -r '.[0].number' <<< "${readiness_matches_json}")"
+          readiness_issue_url="$(jq -r '.[0].url' <<< "${readiness_matches_json}")"
+
+          gh issue view "${readiness_issue_number}" \
+            --repo "${GITHUB_REPO}" \
+            --json body \
+            --jq '.body' > "${issue_body_file}"
+
+          require_regex '^ready:[[:space:]]*true$' "ready: true"
+          require_regex '^risk_level:[[:space:]]*none$' "risk_level: none"
+          if ! awk '
+            /^blocking_items:[[:space:]]*$/ { in_block = 1; next }
+            in_block && /^[a-z_]+:[[:space:]]*/ { in_block = 0 }
+            in_block && /^[[:space:]]*-[[:space:]]*none[[:space:]]*$/ { found_none = 1 }
+            END { exit(found_none ? 0 : 1) }
+          ' "${issue_body_file}"; then
+            fail_with "Release-readiness issue #${readiness_issue_number} is missing required field: blocking_items contains '- none'."
+          fi
+          require_fixed '- Branch-of-record: `true`' "Branch-of-record: true"
+          require_fixed '- Base comparison: `main..dev`' "Base comparison: main..dev"
+          require_regex '^main_to_dev_sync_required:[[:space:]]*true$' "main_to_dev_sync_required: true"
+          require_regex 'security_token_source:[[:space:]]*release-readiness-secret' "security_token_source: release-readiness-secret"
+          require_regex 'CodeQL collection status:[[:space:]]*`?available`?' "CodeQL collection status: available"
+          require_regex 'Dependabot collection status:[[:space:]]*`?available`?' "Dependabot collection status: available"
+          require_regex 'Secret-scanning collection status:[[:space:]]*`?available`?' "Secret-scanning collection status: available"
+          require_regex 'CodeQL default-setup status:[[:space:]]*`?available`?' "CodeQL default-setup status: available"
+          require_regex 'Final pending:[[:space:]]*`?0`?' "final pending checks: 0"
+
+          if ! grep -Fq -- "Dev SHA sampled for check-runs: \`${dev_sha}\`" "${issue_body_file}"; then
+            fail_with "Release-readiness issue is stale; rerun Release Readiness on dev before opening release PR."
+          fi
+
+          release_notes_draft="$(grep -E '^release_notes_draft:[[:space:]]*' "${issue_body_file}" | head -n 1 | sed -E 's/^release_notes_draft:[[:space:]]*//')"
+          validation_summary="$(grep -E '^validation_summary:[[:space:]]*' "${issue_body_file}" | head -n 1 | sed -E 's/^validation_summary:[[:space:]]*//')"
+          if [ -z "${release_notes_draft}" ]; then
+            fail_with "Release-readiness issue #${readiness_issue_number} is missing required field: release_notes_draft."
+          fi
+          if [ -z "${validation_summary}" ]; then
+            fail_with "Release-readiness issue #${readiness_issue_number} is missing required field: validation_summary."
+          fi
+
+          extract_section "Deterministic Check Summary" "${deterministic_check_file}"
+          extract_section "Deterministic Security Summary" "${deterministic_security_file}"
+          extract_section "Included PRs (Deterministic Match)" "${included_prs_file}"
+          extract_section "Changed Surfaces" "${changed_surfaces_raw_file}"
+          extract_section "P0/P1 Checklist" "${p0_p1_checklist_file}"
+          extract_section "Human Decision" "${human_decision_file}"
+
+          awk '
+            NR == 1 { print; next }
+            /^### Diff Stat/ { exit }
+            { print }
+          ' "${changed_surfaces_raw_file}" > "${changed_surfaces_file}"
+
+          if [ ! -s "${changed_surfaces_file}" ]; then
+            fail_with "Release-readiness issue #${readiness_issue_number} is missing required section content: Changed Surfaces."
+          fi
+
+          cat > "${pr_body_file}" <<EOF
+          ## Context
+
+          This is the human-gated release PR from \`dev\` to \`main\`.
+
+          ## Release Readiness
+
+          - Readiness issue: #${readiness_issue_number}
+          - Readiness issue URL: ${readiness_issue_url}
+          - Source branch: \`dev\`
+          - Target branch: \`main\`
+          - Current dev SHA: \`${dev_sha}\`
+          - Readiness status: ready
+          - Risk level: none
+
+          ## Readiness Packet
+
+          ### Release Notes Draft
+
+          - ${release_notes_draft}
+
+          ### Validation Summary
+
+          - ${validation_summary}
+
+          EOF
+
+          append_packet_section "Deterministic Security Summary" "${deterministic_security_file}"
+          append_packet_section "Deterministic Check Summary" "${deterministic_check_file}"
+          append_packet_section "Included PRs (Deterministic Match)" "${included_prs_file}"
+          append_packet_section "Changed Surfaces" "${changed_surfaces_file}"
+          append_packet_section "P0/P1 Checklist" "${p0_p1_checklist_file}"
+          append_packet_section "Human Decision Checklist" "${human_decision_file}"
+
+          cat >> "${pr_body_file}" <<EOF
+          ## Post-Merge Requirement
+
+          After this PR is squash-merged into \`main\`, sync \`main\` back into \`dev\` with a merge commit.
+          Never reset/rebase/force-push \`dev\`.
+
+          ## Human Approval
+
+          This PR must be reviewed and merged by a maintainer. The workflow does not auto-merge or
+          publish.
+          EOF
+
+          pr_matches_json="$(
+            gh pr list \
+              --repo "${GITHUB_REPO}" \
+              --state open \
+              --base "${RELEASE_PR_BASE}" \
+              --head "${RELEASE_PR_HEAD}" \
+              --limit 50 \
+              --json number,url,title
+          )"
+          pr_match_count="$(jq 'length' <<< "${pr_matches_json}")"
+
+          if [ "${pr_match_count}" -gt 1 ]; then
+            duplicate_prs="$(jq -r '.[].number' <<< "${pr_matches_json}" | paste -sd "," -)"
+            fail_with "Expected at most one open ${RELEASE_PR_HEAD} -> ${RELEASE_PR_BASE} PR but found ${pr_match_count}: #${duplicate_prs}."
+          fi
+
+          pr_action="create"
+          existing_pr_number=""
+          existing_pr_url=""
+          if [ "${pr_match_count}" -eq 1 ]; then
+            pr_action="update"
+            existing_pr_number="$(jq -r '.[0].number' <<< "${pr_matches_json}")"
+            existing_pr_url="$(jq -r '.[0].url' <<< "${pr_matches_json}")"
+          fi
+
+          action_result="would ${pr_action}"
+          release_pr_number="${existing_pr_number}"
+          release_pr_url="${existing_pr_url}"
+
+          if [ "${dry_run}" = "false" ]; then
+            if [ "${pr_action}" = "update" ]; then
+              gh pr edit "${existing_pr_number}" \
+                --repo "${GITHUB_REPO}" \
+                --title "${RELEASE_PR_TITLE}" \
+                --body-file "${pr_body_file}"
+            else
+              gh pr create \
+                --repo "${GITHUB_REPO}" \
+                --base "${RELEASE_PR_BASE}" \
+                --head "${RELEASE_PR_HEAD}" \
+                --title "${RELEASE_PR_TITLE}" \
+                --body-file "${pr_body_file}"
+            fi
+
+            canonical_pr_json="$(
+              gh pr list \
+                --repo "${GITHUB_REPO}" \
+                --state open \
+                --base "${RELEASE_PR_BASE}" \
+                --head "${RELEASE_PR_HEAD}" \
+                --limit 1 \
+                --json number,url
+            )"
+            release_pr_number="$(jq -r '.[0].number // empty' <<< "${canonical_pr_json}")"
+            release_pr_url="$(jq -r '.[0].url // empty' <<< "${canonical_pr_json}")"
+            if [ -z "${release_pr_number}" ] || [ -z "${release_pr_url}" ]; then
+              fail_with "Failed to resolve release PR metadata after ${pr_action}."
+            fi
+
+            available_labels_json="$(
+              gh label list \
+                --repo "${GITHUB_REPO}" \
+                --limit 200 \
+                --json name
+            )"
+
+            apply_label_if_exists() {
+              local label_name="$1"
+              if jq -e --arg label_name "${label_name}" '.[] | select(.name == $label_name)' <<< "${available_labels_json}" >/dev/null; then
+                if gh pr edit "${release_pr_number}" --repo "${GITHUB_REPO}" --add-label "${label_name}" >/dev/null; then
+                  echo "- Applied label: \`${label_name}\`" >> "${label_notes_file}"
+                else
+                  echo "- Warning: failed to apply label \`${label_name}\`; continuing." | tee -a "${label_notes_file}" >&2
+                fi
+              else
+                echo "- Skipped missing label: \`${label_name}\`" >> "${label_notes_file}"
+              fi
+            }
+
+            apply_label_if_exists "agent-ready"
+            apply_label_if_exists "card/tooling"
+            apply_label_if_exists "release"
+
+            if [ "${pr_action}" = "create" ]; then
+              action_result="created"
+            else
+              action_result="updated"
+            fi
+          fi
+
+          {
+            echo "## Open Release PR"
+            echo
+            echo "- dry-run mode: \`${dry_run}\`"
+            echo "- action: ${action_result}"
+            if [ -n "${release_pr_url}" ]; then
+              echo "- release PR URL: ${release_pr_url}"
+            else
+              echo "- release PR URL: (none; would create on non-dry run)"
+            fi
+            echo "- readiness issue number: #${readiness_issue_number}"
+            echo "- readiness issue URL: ${readiness_issue_url}"
+            echo "- dev SHA: \`${dev_sha}\`"
+            echo "- base/head: \`${RELEASE_PR_BASE} <- ${RELEASE_PR_HEAD}\`"
+            echo "- merge/publish: not performed (workflow does not auto-merge or publish)"
+            echo
+            if [ -s "${label_notes_file}" ]; then
+              echo "### Label Handling"
+              cat "${label_notes_file}"
+              echo
+            fi
+            if [ "${dry_run}" = "true" ]; then
+              echo "### Would-Be PR Body"
+              echo
+              cat "${pr_body_file}"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Context

- Implements a human-triggered release-PR lane after release-readiness became trustworthy.
- Scope is tooling + skill-pattern only (`.github/workflows` + repo-local skill guidance).
- No runtime source code changed.

## Summary

- Added `.github/workflows/open-release-pr.yml` (`workflow_dispatch` only) with `dry_run` input.
- Workflow validates the single open `Release readiness: dev -> main` issue before acting.
- Validation gates require readiness/body facts including `ready: true`, `risk_level: none`,
  `blocking_items: - none`, branch-of-record true, base comparison `main..dev`,
  `main_to_dev_sync_required: true`, required security collection statuses, and final pending checks
  equal to zero.
- Workflow requires issue staleness protection against current `origin/dev` SHA via
  `Dev SHA sampled for check-runs: <current-sha>`.
- On `dry_run=true`, workflow renders would-be action/body to `GITHUB_STEP_SUMMARY` and does not
  create/update a PR.
- On `dry_run=false`, workflow opens or updates exactly one `dev -> main` PR (`Release: dev -> main`),
  adds labels when available, and never merges/publishes/mutates branches.
- Updated `.agents/skills/plaited-development/SKILL.md` release strategy guidance to mark
  open-release-PR as implemented/manual and explicitly no auto-merge/no publish.
- No branch-mutating automation added.
- No auto-merge added.
- No publish automation added.
- Workflow is manual only.
- Readiness issue must be current and `ready: true`.
- Dry-run behavior is implemented; remote dispatch of this brand-new workflow is blocked until it
  exists on the default branch.

## Changed Files

- `.github/workflows/open-release-pr.yml`
- `.agents/skills/plaited-development/SKILL.md`

## Validation

- Targeted tests:
  - skipped (workflow YAML + skill prose only; no runtime/code path changes)
- `bun --bun tsc --noEmit`:
  - skipped (no TypeScript/runtime source touched)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/open-release-pr.yml"); puts "yaml ok"'`
  - pass (`yaml ok`)
- `rg -n "workflow_dispatch|dry_run|pull-requests: write|issues: read|contents: write|actions: write|gh pr create|gh pr edit|gh pr merge|gh release|npm publish|bun publish|git push|ready: true|risk_level: none|Branch-of-record|main_to_dev_sync_required|security_token_source|Dev SHA sampled|GITHUB_STEP_SUMMARY|Open Release PR|open-release-pr|does not auto-merge|does not publish|dev -> main|main -> dev" .github/workflows/open-release-pr.yml .agents/skills/plaited-development/SKILL.md`
  - pass (required strings present; forbidden commands/permissions absent in this slice)
- `bunx biome check --write .github/workflows/open-release-pr.yml .agents/skills/plaited-development/SKILL.md`
  - returns "No files were processed" (both paths ignored by current Biome config)
- `gh workflow run open-release-pr.yml --repo plaited/plaited --ref agent/open-release-pr-workflow -f dry_run=true`
  - fails with `HTTP 404: workflow open-release-pr.yml not found on the default branch`
  - this is expected for a newly introduced workflow file not yet present on `dev`

## Known Failures / Drift

- Remote `workflow_dispatch` dry-run cannot be executed pre-merge because GitHub requires the
  workflow to exist on the repository default branch for dispatch by file name.
- No other known failures in this slice.

## Review Notes / Residual Risks

- Readiness packet extraction is heading-based and intentionally strict; if release-readiness issue
  headings are renamed, the workflow fails safe.
- Label application is best-effort and non-fatal by design.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
