### PR TITLE
fix(workflows): ignore release operator checks in readiness

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -85,7 +85,7 @@ jobs:
           max_check_wait_seconds=180
           check_poll_interval_seconds=15
           checks_waited_seconds=0
-          checks_ignored_release_readiness=0
+          checks_ignored_release_operator=0
 
           gh pr list \
             --repo "${GITHUB_REPO}" \
@@ -103,50 +103,50 @@ jobs:
           }
 
           count_checks() {
-            checks_ignored_release_readiness="$(
+            checks_ignored_release_operator="$(
               jq '
-                def is_release_readiness_self_check:
-                  (.name // "") == "release-readiness"
-                  and (.app.slug // "") == "github-actions";
-                [.check_runs[] | select(is_release_readiness_self_check)] | length
+                def is_release_operator_check:
+                  ((.app.slug // "") == "github-actions")
+                  and (((.name // "") == "release-readiness") or ((.name // "") == "open-release-pr"));
+                [.check_runs[] | select(is_release_operator_check)] | length
               ' "${checks_file}"
             )"
             checks_total="$(
               jq '
-                def is_release_readiness_self_check:
-                  (.name // "") == "release-readiness"
-                  and (.app.slug // "") == "github-actions";
-                [.check_runs[] | select(is_release_readiness_self_check | not)] | length
+                def is_release_operator_check:
+                  ((.app.slug // "") == "github-actions")
+                  and (((.name // "") == "release-readiness") or ((.name // "") == "open-release-pr"));
+                [.check_runs[] | select(is_release_operator_check | not)] | length
               ' "${checks_file}"
             )"
             checks_failed="$(
               jq '
-                def is_release_readiness_self_check:
-                  (.name // "") == "release-readiness"
-                  and (.app.slug // "") == "github-actions";
+                def is_release_operator_check:
+                  ((.app.slug // "") == "github-actions")
+                  and (((.name // "") == "release-readiness") or ((.name // "") == "open-release-pr"));
                 [
                   .check_runs[]
-                  | select(is_release_readiness_self_check | not)
+                  | select(is_release_operator_check | not)
                   | select((.status // "") == "completed" and ((.conclusion // "") | test("^(failure|timed_out|cancelled|action_required)$")))
                 ] | length
               ' "${checks_file}"
             )"
             checks_pending="$(
               jq '
-                def is_release_readiness_self_check:
-                  (.name // "") == "release-readiness"
-                  and (.app.slug // "") == "github-actions";
-                [.check_runs[] | select(is_release_readiness_self_check | not) | select((.status // "") != "completed")] | length
+                def is_release_operator_check:
+                  ((.app.slug // "") == "github-actions")
+                  and (((.name // "") == "release-readiness") or ((.name // "") == "open-release-pr"));
+                [.check_runs[] | select(is_release_operator_check | not) | select((.status // "") != "completed")] | length
               ' "${checks_file}"
             )"
             checks_neutral_or_skipped="$(
               jq '
-                def is_release_readiness_self_check:
-                  (.name // "") == "release-readiness"
-                  and (.app.slug // "") == "github-actions";
+                def is_release_operator_check:
+                  ((.app.slug // "") == "github-actions")
+                  and (((.name // "") == "release-readiness") or ((.name // "") == "open-release-pr"));
                 [
                   .check_runs[]
-                  | select(is_release_readiness_self_check | not)
+                  | select(is_release_operator_check | not)
                   | select((.status // "") == "completed" and ((.conclusion // "") | test("^(neutral|skipped|stale)$")))
                 ] | length
               ' "${checks_file}"
@@ -408,7 +408,7 @@ jobs:
 
           required_human_checks=$'- Confirm release scope and version bump from commit intent.\n- Confirm no undisclosed security exceptions are being accepted.\n- Confirm validation evidence for changed runtime/package surfaces.\n- Confirm post-release main -> dev sync plan (merge commit, no reset/rebase/force-push).'
 
-          validation_summary="Dev checks_collection_status=${checks_collection_status}; dev_sha=${dev_sha}; checks_waited_seconds=${checks_waited_seconds}; max_check_wait_seconds=${max_check_wait_seconds}; check_poll_interval_seconds=${check_poll_interval_seconds}; security_token_source=${security_token_source}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_scanning_collection_status}; default_setup_collection_status=${default_setup_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}; ignored_release_readiness_self_checks=${checks_ignored_release_readiness}."
+          validation_summary="Dev checks_collection_status=${checks_collection_status}; dev_sha=${dev_sha}; checks_waited_seconds=${checks_waited_seconds}; max_check_wait_seconds=${max_check_wait_seconds}; check_poll_interval_seconds=${check_poll_interval_seconds}; security_token_source=${security_token_source}; codeql_collection_status=${codeql_collection_status}; dependabot_collection_status=${dependabot_collection_status}; secret_scanning_collection_status=${secret_scanning_collection_status}; default_setup_collection_status=${default_setup_collection_status}; check-runs total=${checks_total}; failures=${checks_failed}; pending=${checks_pending}; neutral_or_skipped=${checks_neutral_or_skipped}; ignored_release_operator_checks=${checks_ignored_release_operator}."
 
           cat > "${body_file}" <<EOF
           ## Release Readiness Snapshot
@@ -472,11 +472,11 @@ jobs:
           - Waited seconds: \`${checks_waited_seconds}\`
           - Max wait seconds: \`${max_check_wait_seconds}\`
           - Poll interval seconds: \`${check_poll_interval_seconds}\`
-          - Final check-runs total (excluding release-readiness self-check): \`${checks_total}\`
+          - Final check-runs total (excluding release operator checks): \`${checks_total}\`
           - Final failures: \`${checks_failed}\`
           - Final pending: \`${checks_pending}\`
           - Final neutral/skipped/stale: \`${checks_neutral_or_skipped}\`
-          - Ignored release-readiness self-checks: \`${checks_ignored_release_readiness}\`
+          - Ignored release operator checks: \`${checks_ignored_release_operator}\`
 
           ## Deterministic Security Summary
 


### PR DESCRIPTION
## Context

- Fix a tooling-only false positive in release readiness check aggregation.
- After manual `open-release-pr` dry-runs on `dev`, expected operator gate failures were being
  counted as generic failing checks and flipping readiness to `P1`.
- No runtime source code changed.

## Summary

- Updated `.github/workflows/release-readiness.yml` check-run aggregation to ignore exact release
  operator checks from GitHub Actions only:
  - `release-readiness`
  - `open-release-pr`
- Replaced `is_release_readiness_self_check` logic with `is_release_operator_check` and applied it
  consistently to ignored/total/failed/pending/neutral counts.
- Renamed summary counter from `checks_ignored_release_readiness` to
  `checks_ignored_release_operator`.
- Updated output wording:
  - `ignored_release_operator_checks=<count>` in `validation_summary`
  - `Ignored release operator checks: <count>` in deterministic check summary
- Preserved all existing blocker behavior for non-operator checks.
- No branch-mutating automation added.
- No ruleset changes.
- No release PR automation changes.
- Only exact release operator checks are ignored.
- Real CI/security/test failures remain blockers.

## Changed Files

- `.github/workflows/release-readiness.yml`

## Validation

- Targeted tests:
  - skipped (workflow YAML-only change)
- `bun --bun tsc --noEmit`:
  - skipped (no TypeScript/runtime code changes)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-readiness.yml"); puts "yaml ok"'`
  - pass (`yaml ok`)
- `rg -n "is_release_operator_check|open-release-pr|release-readiness|checks_ignored_release_operator|Ignored release operator checks|test-pr|Analyze|cline-pr-review|pr-description-lint|RELEASE_READINESS_GITHUB_TOKEN|security_api|hide_secret=true|branch_of_record|GITHUB_STEP_SUMMARY|contents: write|actions: write|git push|gh pr create|gh pr merge" .github/workflows/release-readiness.yml`
  - pass (exact operator exclusion present, security/preview behavior present, no broad permission
    or branch-mutating additions)
- Manual branch workflow preview:
  - `gh workflow run release-readiness.yml --repo plaited/plaited --ref agent/release-readiness-ignore-operator-checks`
  - run URL: https://github.com/plaited/plaited/actions/runs/24431616234
  - conclusion: `success`
  - preview evidence from logs:
    - `validation_summary ... failures=0; pending=0; ... ignored_release_operator_checks=3`
    - `Final failures: 0`
    - `Final pending: 0`
    - `Ignored release operator checks: 3`
    - `Preview run from agent/release-readiness-ignore-operator-checks; canonical release-readiness issue was not updated.`

## Known Failures / Drift

- None in this slice.

## Review Notes / Residual Risks

- This ignores only two exact GitHub Actions check names (`release-readiness`,
  `open-release-pr`).
- Any other failing checks (for example test/lint/security/analysis/review workflows) still count
  and still block readiness.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
