### PR TITLE
chore(workflows): harden post-release sync finalization

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -234,8 +234,16 @@ git merge --ff-only origin/dev
 - Publish remains human-gated or release-environment-gated.
 - `dev -> main` release PRs should squash-merge.
 - After squash release, `main -> dev` sync merge commit is required.
+- After every `dev -> main` release merge, immediately run the post-release finalization sequence:
+  - sync `main -> dev` with a merge commit
+  - close or supersede the pre-release readiness issue
+  - run release-readiness again on `dev`
+- Closed historical release-readiness issues must not be treated as the active packet.
+- If `main -> dev` sync uses a PR, merge it with a merge commit (not squash).
 - Do not reset/rebase/force-push `dev` to make release history line up.
 - CodeQL default setup query suite is expected to be `extended` (security-extended equivalent).
+- Squash-release topology can leave `main..dev` commit history noisy; treat branch SHAs and changed
+  files as primary sync evidence.
 
 ### 10.1 Release-Readiness Agent Output Shape
 
@@ -314,11 +322,25 @@ security_summary:
    - does not publish
    - includes readiness packet, release notes draft, validation summary, and `P0`/`P1` checklist
 3. Post-release sync workflow
-   - runs after squash merge to `main` or by manual dispatch
-   - merges `main` back into `dev` with a merge commit
+   - manual `workflow_dispatch` operator workflow
+   - validates current `main`/`dev` refs and emits exact merge-commit instructions
+   - does not auto-push, auto-merge, or publish
+   - sync is executed by the operator locally (or via PR merged with merge commit)
    - never resets/rebases/force-pushes `dev`
 
-### 10.5 Merge Queue Policy
+### 10.5 Post-Release Finalization Checklist
+
+- Merge release PR `dev -> main` with squash merge.
+- Immediately sync `main -> dev` using `git merge --no-ff origin/main` from a fresh `origin/dev`
+  worktree branch.
+- Push sync merge directly to `dev` only when allowed by branch policy; otherwise open a sync PR to
+  `dev` and merge it with a merge commit.
+- Close or supersede the previous readiness issue packet after release merge.
+- Re-run release-readiness on `dev` after the sync merge commit lands on `origin/dev`.
+- Ensure exactly one open issue titled `Release readiness: dev -> main`; duplicates are a blocker.
+- Never reset/rebase/force-push `dev` to reconcile squash topology.
+
+### 10.6 Merge Queue Policy
 
 - Merge queues are deferred.
 - Do not add merge queue requirements yet.

--- a/.github/workflows/post-release-sync.yml
+++ b/.github/workflows/post-release-sync.yml
@@ -1,0 +1,93 @@
+name: Post Release Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: Release branch to sync from.
+        required: true
+        default: main
+      target_branch:
+        description: Integration branch to sync into.
+        required: true
+        default: dev
+
+permissions:
+  contents: read
+
+jobs:
+  post-release-sync-guide:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      BASE_BRANCH: ${{ inputs.base_branch }}
+      TARGET_BRANCH: ${{ inputs.target_branch }}
+      WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate refs and render operator instructions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${BASE_BRANCH}" != "main" ] || [ "${TARGET_BRANCH}" != "dev" ]; then
+            echo "This workflow is scoped to main -> dev finalization only." >&2
+            echo "Use base_branch=main and target_branch=dev." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin "${BASE_BRANCH}" "${TARGET_BRANCH}"
+
+          base_sha="$(git rev-parse "origin/${BASE_BRANCH}")"
+          target_sha="$(git rev-parse "origin/${TARGET_BRANCH}")"
+          merge_base_sha="$(git merge-base "origin/${BASE_BRANCH}" "origin/${TARGET_BRANCH}")"
+          base_ahead_of_target_count="$(git rev-list --count "origin/${TARGET_BRANCH}..origin/${BASE_BRANCH}")"
+          target_ahead_of_base_count="$(git rev-list --count "origin/${BASE_BRANCH}..origin/${TARGET_BRANCH}")"
+
+          sync_required="false"
+          if [ "${base_ahead_of_target_count}" -gt 0 ]; then
+            sync_required="true"
+          fi
+
+          cat <<EOF >> "${GITHUB_STEP_SUMMARY}"
+          ## Post-Release Sync Snapshot
+
+          - Workflow run: `${WORKFLOW_RUN_URL}`
+          - Base branch: `${BASE_BRANCH}` at `${base_sha}`
+          - Target branch: `${TARGET_BRANCH}` at `${target_sha}`
+          - Merge base: `${merge_base_sha}`
+          - Base commits ahead of target: `${base_ahead_of_target_count}`
+          - Target commits ahead of base: `${target_ahead_of_base_count}`
+          - main -> dev sync required: `${sync_required}`
+
+          ## Required Operator Commands
+
+          ```bash
+          git fetch origin main dev
+          git worktree add .worktrees/post-release-main-sync -b chore/post-release-main-sync origin/dev
+          cd .worktrees/post-release-main-sync
+          git merge --no-ff origin/main -m "chore(release): sync main back to dev"
+          git push origin HEAD:dev
+          ```
+
+          If direct push to `dev` is blocked, open a PR to `dev` from that branch and merge with
+          **merge commit** (not squash).
+
+          ## Policy Guardrails
+
+          - Never reset/rebase/force-push `dev` to reconcile squash-release topology.
+          - Do not publish from this workflow.
+          - Do not auto-merge from this workflow.
+          - Keep permissions minimal; this workflow does not mutate branches.
+          EOF
+
+          if [ "${sync_required}" = "true" ]; then
+            echo "main -> dev sync is required." >&2
+          else
+            echo "main is already merged into dev; no sync merge commit required." >&2
+          fi

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -49,6 +49,7 @@ jobs:
           diff_stat_file="${work_dir}/main-to-dev.diffstat"
           changed_files_file="${work_dir}/main-to-dev.changed-files"
           commit_shas_file="${work_dir}/main-to-dev.commit-shas"
+          main_ahead_commit_shas_file="${work_dir}/dev-to-main.commit-shas"
           prs_file="${work_dir}/dev-merged-prs.json"
           checks_file="${work_dir}/dev-check-runs.json"
           codeql_file="${work_dir}/codeql-open-alerts.json"
@@ -81,6 +82,7 @@ jobs:
           git diff --stat origin/main..origin/dev > "${diff_stat_file}"
           git diff --name-only origin/main..origin/dev > "${changed_files_file}"
           git rev-list origin/main..origin/dev > "${commit_shas_file}"
+          git rev-list origin/dev..origin/main > "${main_ahead_commit_shas_file}"
           dev_sha="$(git rev-parse origin/dev)"
           max_check_wait_seconds=180
           check_poll_interval_seconds=15
@@ -210,6 +212,7 @@ jobs:
 
           commit_count="$(wc -l < "${log_file}" | tr -d ' ')"
           changed_file_count="$(wc -l < "${changed_files_file}" | tr -d ' ')"
+          main_ahead_commit_count="$(wc -l < "${main_ahead_commit_shas_file}" | tr -d ' ')"
 
           codeql_total="$(jq 'length' "${codeql_file}")"
           codeql_high="$(jq '[.[] | select((.rule.security_severity_level // "") | ascii_downcase == "high")] | length' "${codeql_file}")"
@@ -315,8 +318,13 @@ jobs:
           )"
 
           main_to_dev_sync_required="false"
-          if [ "${commit_count}" -gt 0 ]; then
+          if [ "${main_ahead_commit_count}" -gt 0 ]; then
             main_to_dev_sync_required="true"
+          fi
+
+          topology_limitation="none"
+          if [ "${commit_count}" -gt 0 ] && [ "${changed_file_count}" -eq 0 ]; then
+            topology_limitation="main..dev commit count can stay high after squash releases; use changed files plus branch SHAs as primary release signal."
           fi
 
           suggested_version_bump="none"
@@ -421,7 +429,9 @@ jobs:
           - Base comparison: \`main..dev\`
           - Dev SHA sampled for check-runs: \`${dev_sha}\`
           - Commit count ahead of main: ${commit_count}
+          - Main commit count ahead of dev: ${main_ahead_commit_count}
           - Changed file count ahead of main: ${changed_file_count}
+          - Squash-topology limitation: ${topology_limitation}
 
           ## Release-Readiness Output
 
@@ -439,6 +449,7 @@ jobs:
           $(echo "${included_commit_lines}" | sed 's/^/  /')
           changed_surfaces:
           $(echo "${changed_surfaces_lines}" | sed 's/^/  /')
+          topology_limitation: ${topology_limitation}
           validation_summary: ${validation_summary}
           main_to_dev_sync_required: ${main_to_dev_sync_required}
           security_summary:
@@ -517,6 +528,7 @@ jobs:
           - Release PR should use squash merge.
           - After squash release, sync \`main -> dev\` with a merge commit.
           - Never reset/rebase/force-push \`dev\`.
+          - Topology limitation note: \`${topology_limitation}\`
 
           ## Human Decision
 
@@ -528,9 +540,20 @@ jobs:
           sed -i 's/^          //' "${body_file}"
 
           if [ "${branch_of_record}" = "true" ]; then
+            matching_open_issues_json="$(
+              gh issue list --repo "${GITHUB_REPO}" --state open --limit 200 --json number,title,url \
+                | jq -c --arg title "${TITLE}" '[.[] | select(.title == $title) | {number, url}]'
+            )"
+            matching_open_issue_count="$(
+              echo "${matching_open_issues_json}" | jq 'length'
+            )"
+            if [ "${matching_open_issue_count}" -gt 1 ]; then
+              echo "Multiple open readiness issues found for '${TITLE}'. Resolve duplicates first." >&2
+              echo "${matching_open_issues_json}" | jq -r '.[] | "- #\(.number) \(.url)"' >&2
+              exit 1
+            fi
             existing_issue_number="$(
-              gh issue list --repo "${GITHUB_REPO}" --state open --limit 200 --json number,title \
-                | jq -r --arg title "${TITLE}" 'map(select(.title == $title)) | first | .number // empty'
+              echo "${matching_open_issues_json}" | jq -r '.[0].number // empty'
             )"
 
             if [ -n "${existing_issue_number}" ]; then


### PR DESCRIPTION
## Context

- Release PR [#249](https://github.com/plaited/plaited/pull/249) was squash-merged from `dev -> main`.
- Pre-release readiness issue [#241](https://github.com/plaited/plaited/issues/241) was already closed as historical packet state.
- Required follow-up was post-release `main -> dev` sync + fresh readiness run + durable finalization policy.

## Summary

- Performed the required sync merge commit from `origin/main` into `origin/dev` and pushed it directly:
  - Sync commit: `55d8fba3a636afaf4bec1900707b2d7f8ded4217`
- Re-ran release-readiness on `dev` after sync:
  - Run: https://github.com/plaited/plaited/actions/runs/24433385542
- Active readiness issue now: https://github.com/plaited/plaited/issues/250 (open)
- Closed historical issue [#241](https://github.com/plaited/plaited/issues/241) was not reused by the workflow.
- Added a conservative manual post-release sync workflow and narrowed readiness issue handling.

## Changed Files

- `.github/workflows/release-readiness.yml`
  - Keep readiness issue lookup scoped to open issues and fail if duplicate open readiness issues exist.
  - Derive `main_to_dev_sync_required` from `dev..main` (actual unsynced release commits).
  - Add explicit squash-topology limitation signal in output.
- `.github/workflows/post-release-sync.yml`
  - New manual (`workflow_dispatch`) operator guidance workflow.
  - Validates refs and prints exact operator commands; does not mutate branches.
- `.agents/skills/plaited-development/SKILL.md`
  - Adds explicit post-release finalization checklist/policy:
    - immediate `main -> dev` merge commit
    - supersede/close old readiness packet
    - rerun readiness after sync
    - never reset/rebase/force-push `dev`
    - merge-commit requirement when sync uses PR

## Validation

- Targeted tests:
  - Skipped executable tests (tooling/docs workflow slice only; no runtime source code touched)
- `bun --bun tsc --noEmit`:
  - Skipped (no TypeScript/runtime edits)
- YAML parse:
  - `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "yaml ok"'`
  - Result: `yaml ok`
- Search checks:
  - `rg -n "post-release|main -> dev|sync main|Release readiness: dev -> main|state:open|gh issue create|gh issue edit|workflow_dispatch|contents: write|actions: write|git push|gh pr merge|reset|rebase|force-push" .github/workflows .agents/skills/plaited-development/SKILL.md`
- Biome:
  - `bunx biome check --write .github/workflows/*.yml .agents/skills/plaited-development/SKILL.md`
  - Result: paths ignored by repo Biome config; no files processed.

## Known Failures / Drift

- `main..dev` commit history remains noisy under squash-release topology even after sync merge.
- Readiness output now calls this out as a topology limitation and uses `dev..main` for sync-required detection.

## Review Notes / Residual Risks

- No publish automation added.
- No auto-merge behavior added.
- No workflow branch mutation added in `post-release-sync` (instruction-only).
- No direct-push workflow permissions added (`contents: write` not added to new workflow).

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
