### PR TITLE
docs(github): clarify maintainer-only agent intake labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,14 @@ title: "[Bug] "
 labels:
   - needs-triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Maintainers triage all issues and may later apply agent intake labels when work is suitable.
+        `agent-ready`, `agent-planning`, and `card/*` are maintainer-only labels. Do not request or
+        assume these labels on intake issues. This form only auto-applies low-trust triage labels
+        such as `needs-triage`.
+
   - type: input
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Issue intake policy
+    url: https://github.com/plaited/plaited/blob/dev/CONTRIBUTING.md#issue-based-intake
+    about: Use Bug report and Feature request issues for intake; maintainers triage and apply any agent labels.
   - name: Questions and discussions
     url: https://github.com/orgs/plaited/discussions
-    about: Use Discussions for open-ended questions or conversation.
+    about: Use Discussions for open-ended conversation, not bug/feature intake.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,6 +4,14 @@ title: "[Feature] "
 labels:
   - needs-triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Maintainers triage all issues and may later apply agent intake labels when work is suitable.
+        `agent-ready`, `agent-planning`, and `card/*` are maintainer-only labels. Do not request or
+        assume these labels on intake issues. This form only auto-applies low-trust triage labels
+        such as `needs-triage`.
+
   - type: input
     id: summary
     attributes:


### PR DESCRIPTION
## Context

- Tooling/docs-only slice to clarify GitHub issue intake trust semantics for agent labels.
- This runs in parallel with issue-ingestion implementation and does not alter runtime behavior.

## Summary

- Added maintainer-only guidance to bug and feature issue forms stating maintainers may later apply
  agent intake labels when suitable.
- Explicitly states reporters should not request or assume `agent-ready`, `agent-planning`, or
  `card/*` labels.
- Kept template defaults low-trust (`needs-triage` only).
- Updated issue template config links/messaging to reinforce issue-based intake and maintainer
  triage.

## Changed Files

- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml`

## Validation

- Targeted tests:
  - Skipped executable tests (YAML/docs-only template guidance changes).
  - `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |path| YAML.load_file(path); puts "yaml ok: #{path}" }'`
  - `rg -n "agent-ready|agent-planning|card/|maintainer-only|needs-triage|labels:" .github/ISSUE_TEMPLATE CONTRIBUTING.md`
  - `bunx biome check --write .github/ISSUE_TEMPLATE/*.yml CONTRIBUTING.md` (paths ignored by Biome config)
- `bun --bun tsc --noEmit`:
  - Skipped because this slice changes only YAML/docs template text and no TypeScript or executable
    runtime/tooling code.

## Known Failures / Drift

- Biome reported the provided template/docs paths are ignored by current configuration; relied on
  YAML parse + direct inspection/search validation.

## Review Notes / Residual Risks

- No runtime source files changed.
- No issue template default labels were expanded beyond `needs-triage`.
- No GitHub issues or repository labels were mutated; only this PR was opened and labeled per
  request.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
