### PR TITLE
fix(tooling): remove lifecycle resolution alias

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -234,7 +234,7 @@ bun run agent:issues:plan -- '{"repo":"plaited/plaited","limit":5}' --human
   - requires `reason`
   - add `agent-needs-human`, `agent-blocked`
 - `completed`
-  - `resolution` supports `full`, `partial`, and `unknown` (`fully-resolved` is accepted as an alias)
+  - canonical `resolution` values are exactly `full`, `partial`, and `unknown`
   - omitted `resolution` is treated as `unknown` and warns that maintainer classification is required
   - `full`: add `agent-done`, remove active/blocker labels and `needs-triage`, model `wouldCloseIssue: true`
   - `partial` and `unknown`: keep issue open, add/keep `agent-needs-human`

--- a/.agents/skills/plaited-development/references/issue-lifecycle.md
+++ b/.agents/skills/plaited-development/references/issue-lifecycle.md
@@ -27,8 +27,7 @@ This reference describes the read-only lifecycle planner command:
 - `currentLabels?: string[]` (preferred for deterministic offline planning)
 - `prUrl?: string`
 - `reason?: string`
-- `resolution?: "full" | "partial" | "unknown"`
-  - `"fully-resolved"` is accepted as an alias for `"full"`
+- `resolution?: "full" | "partial" | "unknown"` (canonical values only)
 - `commentBody?: string`
 
 ## Output

--- a/scripts/plan-agent-issue-lifecycle.ts
+++ b/scripts/plan-agent-issue-lifecycle.ts
@@ -2,7 +2,7 @@ import * as z from 'zod'
 import { type CliFlags, makeCli } from '../src/cli/utils/cli.ts'
 
 const TransitionSchema = z.enum(['plan-started', 'pr-opened', 'blocked', 'completed', 'abandoned'])
-const ResolutionSchema = z.enum(['full', 'fully-resolved', 'partial', 'unknown'])
+const ResolutionSchema = z.enum(['full', 'partial', 'unknown'])
 
 export type LifecycleTransition = z.infer<typeof TransitionSchema>
 
@@ -85,8 +85,6 @@ type TransitionPlan = {
   wouldCloseIssue: boolean
 }
 
-type LifecycleResolution = 'full' | 'partial' | 'unknown'
-
 const GITHUB_ISSUE_LABELS_SCHEMA = z.object({
   labels: z.array(
     z.object({
@@ -143,18 +141,6 @@ const appendOperatorNote = ({ baseComment, commentBody }: { baseComment: string;
   }
 
   return `${baseComment}\n\nOperator note:\n${commentBody}`
-}
-
-const normalizeResolution = (resolution: z.infer<typeof ResolutionSchema> | undefined): LifecycleResolution => {
-  if (resolution === 'full' || resolution === 'fully-resolved') {
-    return 'full'
-  }
-
-  if (resolution === 'partial') {
-    return 'partial'
-  }
-
-  return 'unknown'
 }
 
 const trimProcessError = ({ stderr, stdout }: { stderr: string; stdout: string }): string => {
@@ -293,15 +279,12 @@ const planTransition = ({ input }: { input: PlanAgentIssueLifecycleResolvedInput
     }
 
     case 'completed': {
-      const resolution = normalizeResolution(input.resolution)
+      const resolution = input.resolution ?? 'unknown'
 
       if (resolution === 'full') {
         const warnings: string[] = []
         if (!input.prUrl) {
           warnings.push('completed full without prUrl; include prUrl when available')
-        }
-        if (input.resolution === 'fully-resolved') {
-          warnings.push('resolution "fully-resolved" is accepted as an alias for "full"')
         }
 
         return {

--- a/scripts/tests/plan-agent-issue-lifecycle.spec.ts
+++ b/scripts/tests/plan-agent-issue-lifecycle.spec.ts
@@ -127,6 +127,21 @@ describe('input validation', () => {
       expect(parsed.error.issues.some((issue) => issue.path.join('.') === 'reason')).toBe(true)
     }
   })
+
+  test('completed rejects legacy full-resolution alias', () => {
+    const legacyAlias = 'fully-' + 'resolved'
+    const parsed = PlanAgentIssueLifecycleInputSchema.safeParse({
+      issue: 123,
+      transition: 'completed',
+      currentLabels: ['agent-ready'],
+      resolution: legacyAlias,
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues.some((issue) => issue.path.join('.') === 'resolution')).toBe(true)
+    }
+  })
 })
 
 describe('transition planning', () => {
@@ -194,20 +209,6 @@ describe('transition planning', () => {
     ])
     expect(output.wouldCloseIssue).toBe(true)
     expect(output.closeIssue).toBe(false)
-  })
-
-  test('completed fully-resolved alias is normalized to full', async () => {
-    const output = await planAgentIssueLifecycle({
-      issue: 123,
-      transition: 'completed',
-      currentLabels: ['agent-ready', 'agent-active', 'agent-pr-open'],
-      resolution: 'fully-resolved',
-      prUrl: 'https://github.com/plaited/plaited/pull/999',
-    })
-
-    expect(output.proposedLabelsToAdd).toEqual(['agent-done'])
-    expect(output.wouldCloseIssue).toBe(true)
-    expect(output.warnings).toContain('resolution "fully-resolved" is accepted as an alias for "full"')
   })
 
   test('completed partial does not add agent-done, adds agent-needs-human, and does not close', async () => {


### PR DESCRIPTION
## Context

- PR #257 introduced `agent:issues:lifecycle` as a dry-run lifecycle planner.
- The planner still accepted a legacy `resolution: "fully-resolved"` alias, but the canonical contract is now only `full | partial | unknown`.

## Summary

- Removed `fully-resolved` from the lifecycle input schema.
- Removed alias normalization and the alias-acceptance warning path.
- Preserved completed-resolution behavior:
  - `full` => full completion plan.
  - `partial` => partial completion plan.
  - `unknown` => maintainer-decision plan.
  - omitted `resolution` => treated as `unknown` with warning.
- Updated tests to drop alias-normalization expectations and assert alias rejection at schema validation.
- Updated plaited-development skill docs to state canonical values are exactly `full`, `partial`, `unknown`.
- Explicitly: `fully-resolved` is no longer accepted.
- Explicitly: no issue/label/comment mutation was added.
- Explicitly: no workflow automation was changed.
- Explicitly: no Kanban/Cline invocation was added.

## Changed Files

- `scripts/plan-agent-issue-lifecycle.ts`
  - removed `fully-resolved` from `ResolutionSchema`
  - removed alias normalization function/path
  - retained dry-run guarantees (`willMutate: false`, `requiresApply: true`, `closeIssue: false`) and existing guardrails
- `scripts/tests/plan-agent-issue-lifecycle.spec.ts`
  - removed alias-normalization test
  - added validation test proving legacy alias input is rejected
  - retained coverage for `completed` with `full`, `partial`, `unknown`, and omitted-resolution fallback plus output schema fields (`wouldCloseIssue`, `proposedLabelsToAdd`, `proposedLabelsToRemove`, `proposedComment`)
- `.agents/skills/plaited-development/SKILL.md`
  - removed alias language
  - documented canonical resolution values only
- `.agents/skills/plaited-development/references/issue-lifecycle.md`
  - removed alias language
  - documented canonical resolution values only

## Validation

- Targeted tests:
  - `bun test scripts/tests/plan-agent-issue-lifecycle.spec.ts` (pass)
  - `bun test scripts/tests/ingest-agent-issues.spec.ts` (pass)
- `bun --bun tsc --noEmit`: pass
- `bunx biome check --write scripts/plan-agent-issue-lifecycle.ts scripts/tests/plan-agent-issue-lifecycle.spec.ts package.json .agents/skills/plaited-development/SKILL.md .agents/skills/plaited-development/references/issue-lifecycle.md`: pass (`Checked 3 files`; markdown files not biome-processed)
- `rg -n "fully-resolved" scripts .agents package.json`: no matches
- `git diff --check`: pass

## Known Failures / Drift

- None observed in this slice.

## Review Notes / Residual Risks

- This is a narrow contract cleanup only; lifecycle transition semantics are unchanged except removing the legacy alias acceptance.
- Omitted `resolution` for `completed` remains supported and still falls back to `unknown` with warning.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
