### PR TITLE
feat: add BP-mediated inference bridge skeleton

### DIFF
--- a/src/inference/inference-bridge.ts
+++ b/src/inference/inference-bridge.ts
@@ -1,0 +1,261 @@
+import type { SnapshotMessage } from '../behavioral/behavioral.schemas.ts'
+import { behavioral } from '../behavioral.ts'
+import { ueid } from '../utils/ueid.ts'
+import { InferenceTrajectorySchema } from './inference.schemas.ts'
+import type {
+  BPNormalizedSnapshot,
+  BridgeEvent,
+  BridgeEventDetail,
+  BridgeEventType,
+  InferenceAdapter,
+  InferenceError,
+  InferencePolicy,
+  InferenceRequest,
+  InferenceResponse,
+  InferenceTrajectory,
+  TrajectoryOutcome,
+} from './inference.types.ts'
+
+/**
+ * BP-Mediated Inference Bridge Implementation
+ *
+ * @remarks
+ * This module implements the runtime bridge that:
+ * - Accepts generic executor-originated inference requests
+ * - Routes them through a behavioral() program
+ * - Calls a fakeable upstream inference adapter
+ * - Returns the upstream response while preserving event/snapshot artifacts for eval
+ *
+ * Default behavior is transparent/pass-through: no blocking, mutation, redaction,
+ * or forked inference. A future policy seam allows bThreads/extensions to
+ * attach before execution.
+ *
+ * @public
+ */
+
+const INFERENCE_BRIDGE_ID = 'inference_bridge'
+
+/** Event types used internally by the bridge */
+const INFERENCE_EVENTS = {
+  REQUEST: 'inference:request',
+  RESPONSE: 'inference:response',
+  ERROR: 'inference:error',
+  POLICY_SEAM: 'inference:policy_seam',
+} as const
+
+/**
+ * Configuration options for the inference bridge.
+ *
+ * @public
+ */
+export type InferenceBridgeOptions = {
+  /** The upstream inference adapter (fakeable for testing). */
+  adapter: InferenceAdapter
+  /** Policy seam for request evaluation. Defaults to pass-through. */
+  policy?: InferencePolicy
+}
+
+/**
+ * Result from executing an inference request through the bridge.
+ *
+ * @public
+ */
+export type InferenceBridgeResult = {
+  /** The inference response from the upstream adapter. */
+  response: InferenceResponse
+  /** The eval-compatible trajectory artifact. */
+  trajectory: InferenceTrajectory
+}
+
+/**
+ * Normalize a BP snapshot message to eval-compatible record.
+ */
+const normalizeSnapshot = (snapshot: SnapshotMessage, requestId: string): BPNormalizedSnapshot => {
+  return {
+    snapshotId: ueid('snap_'),
+    requestId,
+    timestamp: Date.now(),
+    kind: snapshot.kind,
+    data: snapshot,
+  }
+}
+
+/**
+ * Emit a bridge event to the trajectory.
+ */
+const emitBridgeEvent = (
+  events: BridgeEvent[],
+  type: BridgeEventType,
+  requestId: string,
+  detail: BridgeEventDetail,
+): void => {
+  events.push({
+    type,
+    timestamp: Date.now(),
+    requestId,
+    detail,
+  })
+}
+
+/**
+ * Creates a BP-mediated inference bridge.
+ *
+ * @remarks
+ * The bridge uses a behavioral() program to coordinate inference requests.
+ * By default, requests pass through transparently. The policy seam allows
+ * bThreads/extensions to attach and evaluate requests before execution.
+ *
+ * @param options - Bridge configuration including the inference adapter.
+ * @returns Bridge execute function.
+ *
+ * @example
+ * ```typescript
+ * const fakeAdapter: InferenceAdapter = {
+ *   execute: async (request) => ({
+ *     requestId: request.requestId,
+ *     data: { content: `Response to: ${JSON.stringify(request.payload)}` }
+ *   })
+ * }
+ *
+ * const bridge = createInferenceBridge({ adapter: fakeAdapter })
+ * const result = await bridge.execute({
+ *   requestId: 'req-1',
+ *   executor: { executorId: 'test' },
+ *   payload: { prompt: 'Hello' }
+ * })
+ * ```
+ *
+ * @public
+ */
+export const createInferenceBridge = (options: InferenceBridgeOptions) => {
+  const { adapter, policy = { evaluate: () => true } } = options
+
+  /**
+   * Execute an inference request through the BP-mediated bridge.
+   *
+   * @param request - The inference request to execute.
+   * @returns Promise resolving to the inference response and trajectory.
+   */
+  const execute = async (request: InferenceRequest): Promise<InferenceBridgeResult> => {
+    const trajectoryId = ueid('traj_')
+    const events: BridgeEvent[] = []
+    const snapshots: BPNormalizedSnapshot[] = []
+
+    // Create a fresh behavioral program for this request
+    const { trigger, useSnapshot } = behavioral()
+
+    // Subscribe to BP snapshots for trajectory preservation
+    const disconnectSnapshot = useSnapshot((snapshot: SnapshotMessage) => {
+      snapshots.push(normalizeSnapshot(snapshot, request.requestId))
+    })
+
+    // Emit request event
+    emitBridgeEvent(events, INFERENCE_EVENTS.REQUEST, request.requestId, {
+      type: 'inference:request',
+      request,
+    })
+
+    // Policy seam evaluation via BP trigger
+    const allowed = policy.evaluate(request)
+    emitBridgeEvent(events, INFERENCE_EVENTS.POLICY_SEAM, request.requestId, {
+      type: 'inference:policy_seam',
+      request,
+      allowed,
+    })
+
+    // Trigger policy seam event through BP
+    trigger({
+      type: INFERENCE_EVENTS.POLICY_SEAM,
+      detail: { request, allowed },
+    })
+
+    let response: InferenceResponse
+    let outcome: TrajectoryOutcome
+
+    if (!allowed) {
+      // Request was blocked by policy
+      outcome = { status: 'blocked', reason: 'policy evaluation returned false' }
+      disconnectSnapshot()
+      return buildResult(trajectoryId, request.requestId, events, snapshots, outcome)
+    }
+
+    try {
+      // Execute inference via adapter
+      response = await adapter.execute(request)
+
+      // Emit response event
+      emitBridgeEvent(events, INFERENCE_EVENTS.RESPONSE, request.requestId, {
+        type: 'inference:response',
+        response,
+      })
+
+      // Trigger response event through BP
+      trigger({
+        type: INFERENCE_EVENTS.RESPONSE,
+        detail: { response },
+      })
+
+      outcome = { status: 'success', response }
+    } catch (error) {
+      const inferenceError: InferenceError = {
+        requestId: request.requestId,
+        message: error instanceof Error ? error.message : String(error),
+        code: error instanceof Error ? error.name : undefined,
+      }
+
+      // Emit error event
+      emitBridgeEvent(events, INFERENCE_EVENTS.ERROR, request.requestId, {
+        type: 'inference:error',
+        error: inferenceError,
+      })
+
+      // Trigger error event through BP
+      trigger({
+        type: INFERENCE_EVENTS.ERROR,
+        detail: { error: inferenceError },
+      })
+
+      outcome = { status: 'error', error: inferenceError }
+      response = { requestId: request.requestId, data: {} }
+    }
+
+    disconnectSnapshot()
+
+    return buildResult(trajectoryId, request.requestId, events, snapshots, outcome)
+  }
+
+  const buildResult = (
+    trajectoryId: string,
+    requestId: string,
+    events: BridgeEvent[],
+    snapshots: BPNormalizedSnapshot[],
+    outcome: TrajectoryOutcome,
+  ): InferenceBridgeResult => {
+    const trajectory: InferenceTrajectory = {
+      trajectoryId,
+      requestId,
+      events,
+      snapshots,
+      outcome,
+    }
+
+    // Validate trajectory schema
+    InferenceTrajectorySchema.parse(trajectory)
+
+    const response: InferenceResponse =
+      outcome.status === 'success'
+        ? outcome.response
+        : { requestId, data: { error: outcome.status === 'error' ? outcome.error.message : outcome.reason } }
+
+    return { response, trajectory }
+  }
+
+  return { execute, id: INFERENCE_BRIDGE_ID }
+}
+
+/**
+ * Type alias for the bridge factory result.
+ *
+ * @public
+ */
+export type InferenceBridge = ReturnType<typeof createInferenceBridge>

--- a/src/inference/inference-bridge.ts
+++ b/src/inference/inference-bridge.ts
@@ -216,7 +216,6 @@ export const createInferenceBridge = (options: InferenceBridgeOptions) => {
       })
 
       outcome = { status: 'error', error: inferenceError }
-      response = { requestId: request.requestId, data: {} }
     }
 
     disconnectSnapshot()

--- a/src/inference/inference.schemas.ts
+++ b/src/inference/inference.schemas.ts
@@ -1,0 +1,199 @@
+import * as z from 'zod'
+
+/**
+ * BP-Mediated Inference Bridge Schemas
+ *
+ * @remarks
+ * This module provides Zod schemas for validating inference bridge types.
+ *
+ * @public
+ */
+
+const SNAPSHOT_KINDS = ['selection', 'deadlock', 'feedback_error', 'extension_error'] as const
+
+/**
+ * Schema for executor metadata.
+ *
+ * @public
+ */
+export const ExecutorMetadataSchema = z.object({
+  executorId: z.string(),
+  sessionId: z.string().optional(),
+  workspace: z.string().optional(),
+})
+
+/**
+ * Schema for inference payload (opaque to the bridge).
+ *
+ * @public
+ */
+export const InferencePayloadSchema = z.record(z.string(), z.unknown())
+
+/**
+ * Schema for a generic executor-originated inference request.
+ *
+ * @public
+ */
+export const InferenceRequestSchema = z.object({
+  requestId: z.string(),
+  correlationId: z.string().optional(),
+  executor: ExecutorMetadataSchema,
+  payload: InferencePayloadSchema,
+})
+
+/**
+ * Schema for inference response data (opaque to the bridge).
+ *
+ * @public
+ */
+export const InferenceResponseDataSchema = z.record(z.string(), z.unknown())
+
+/**
+ * Schema for upstream inference adapter response.
+ *
+ * @public
+ */
+export const InferenceResponseSchema = z.object({
+  requestId: z.string(),
+  data: InferenceResponseDataSchema,
+})
+
+/**
+ * Schema for upstream inference adapter error.
+ *
+ * @public
+ */
+export const InferenceErrorSchema = z.object({
+  requestId: z.string(),
+  message: z.string(),
+  code: z.string().optional(),
+})
+
+/**
+ * Schema for bridge event type discriminator.
+ *
+ * @public
+ */
+export const BridgeEventTypeSchema = z.enum([
+  'inference:request',
+  'inference:response',
+  'inference:error',
+  'inference:policy_seam',
+])
+
+/**
+ * Schema for bridge event detail (discriminated union).
+ *
+ * @public
+ */
+export const BridgeRequestDetailSchema = z.object({
+  type: z.literal('inference:request'),
+  request: InferenceRequestSchema,
+})
+
+export const BridgeResponseDetailSchema = z.object({
+  type: z.literal('inference:response'),
+  response: InferenceResponseSchema,
+})
+
+export const BridgeErrorDetailSchema = z.object({
+  type: z.literal('inference:error'),
+  error: InferenceErrorSchema,
+})
+
+export const BridgePolicySeamDetailSchema = z.object({
+  type: z.literal('inference:policy_seam'),
+  request: InferenceRequestSchema,
+  allowed: z.boolean(),
+})
+
+/**
+ * Discriminated union schema for bridge event details.
+ *
+ * @public
+ */
+export const BridgeEventDetailSchema = z.discriminatedUnion('type', [
+  BridgeRequestDetailSchema,
+  BridgeResponseDetailSchema,
+  BridgeErrorDetailSchema,
+  BridgePolicySeamDetailSchema,
+])
+
+/**
+ * Schema for a bridge event envelope.
+ *
+ * @public
+ */
+export const BridgeEventSchema = z.object({
+  type: BridgeEventTypeSchema,
+  timestamp: z.number(),
+  requestId: z.string(),
+  detail: BridgeEventDetailSchema,
+})
+
+/**
+ * Schema for BP-normalized snapshot record.
+ *
+ * @public
+ */
+export const BPNormalizedSnapshotSchema = z.object({
+  snapshotId: z.string(),
+  requestId: z.string(),
+  timestamp: z.number(),
+  kind: z.enum(SNAPSHOT_KINDS),
+  data: z.unknown(),
+})
+
+/**
+ * Schema for trajectory success outcome.
+ *
+ * @public
+ */
+export const TrajectorySuccessOutcomeSchema = z.object({
+  status: z.literal('success'),
+  response: InferenceResponseSchema,
+})
+
+/**
+ * Schema for trajectory error outcome.
+ *
+ * @public
+ */
+export const TrajectoryErrorOutcomeSchema = z.object({
+  status: z.literal('error'),
+  error: InferenceErrorSchema,
+})
+
+/**
+ * Schema for trajectory blocked outcome.
+ *
+ * @public
+ */
+export const TrajectoryBlockedOutcomeSchema = z.object({
+  status: z.literal('blocked'),
+  reason: z.string(),
+})
+
+/**
+ * Discriminated union schema for trajectory outcomes.
+ *
+ * @public
+ */
+export const TrajectoryOutcomeSchema = z.discriminatedUnion('status', [
+  TrajectorySuccessOutcomeSchema,
+  TrajectoryErrorOutcomeSchema,
+  TrajectoryBlockedOutcomeSchema,
+])
+
+/**
+ * Schema for eval-compatible inference trajectory artifact.
+ *
+ * @public
+ */
+export const InferenceTrajectorySchema = z.object({
+  trajectoryId: z.string(),
+  requestId: z.string(),
+  events: z.array(BridgeEventSchema),
+  snapshots: z.array(BPNormalizedSnapshotSchema),
+  outcome: TrajectoryOutcomeSchema,
+})

--- a/src/inference/inference.ts
+++ b/src/inference/inference.ts
@@ -1,0 +1,54 @@
+/**
+ * BP-Mediated Inference Bridge Module
+ *
+ * @remarks
+ * This module provides the runtime bridge for routing executor-originated inference
+ * traffic through behavioral programming. It enables future policy, MSS, and eval
+ * work to attach to real trajectories.
+ *
+ * The bridge is intentionally narrow: policy-neutral pass-through behavior first,
+ * observable BP snapshots always.
+ *
+ * @public
+ */
+
+// Re-export schemas
+export {
+  BPNormalizedSnapshotSchema,
+  BridgeEventDetailSchema,
+  BridgeEventSchema,
+  BridgeEventTypeSchema,
+  ExecutorMetadataSchema,
+  InferenceErrorSchema,
+  InferencePayloadSchema,
+  InferenceRequestSchema,
+  InferenceResponseDataSchema,
+  InferenceResponseSchema,
+  InferenceTrajectorySchema,
+  TrajectoryBlockedOutcomeSchema,
+  TrajectoryErrorOutcomeSchema,
+  TrajectoryOutcomeSchema,
+  TrajectorySuccessOutcomeSchema,
+} from './inference.schemas.ts'
+// Re-export types from types file
+export type {
+  BPNormalizedSnapshot,
+  BridgeEvent,
+  BridgeEventDetail,
+  BridgeEventType,
+  ExecutorMetadata,
+  InferenceAdapter,
+  InferenceError,
+  InferencePayload,
+  InferencePolicy,
+  InferenceRequest,
+  InferenceResponse,
+  InferenceResponseData,
+  InferenceTrajectory,
+  TrajectoryOutcome,
+} from './inference.types.ts'
+// Re-export policy
+export { defaultInferencePolicy } from './inference.types.ts'
+export type { InferenceBridge, InferenceBridgeOptions, InferenceBridgeResult } from './inference-bridge.ts'
+// Re-export implementation
+export { createInferenceBridge } from './inference-bridge.ts'

--- a/src/inference/inference.types.ts
+++ b/src/inference/inference.types.ts
@@ -1,0 +1,224 @@
+/**
+ * BP-Mediated Inference Bridge Types
+ *
+ * @remarks
+ * This module defines the type contracts for the BP-mediated inference bridge.
+ * The bridge accepts executor-originated inference requests, routes them through
+ * a behavioral() program, calls a fakeable upstream inference adapter, and returns
+ * the upstream response while preserving event/snapshot artifacts for eval.
+ *
+ * @public
+ */
+
+/**
+ * Executor metadata attached to inference requests.
+ *
+ * @public
+ */
+export type ExecutorMetadata = {
+  /** Executor identifier (e.g., 'cline', 'agent-core'). */
+  executorId: string
+  /** Session or conversation context identifier. */
+  sessionId?: string
+  /** Optional workspace root for executor context. */
+  workspace?: string
+}
+
+/**
+ * Generic executor-originated inference request.
+ *
+ * @public
+ */
+export type InferenceRequest = {
+  /** Unique identifier for this request. */
+  requestId: string
+  /** Correlation identifier for related request chains. */
+  correlationId?: string
+  /** Executor metadata for the request origin. */
+  executor: ExecutorMetadata
+  /** The actual inference payload (model-specific). */
+  payload: InferencePayload
+}
+
+/**
+ * Inference payload shape (model-specific, opaque to the bridge).
+ *
+ * @remarks
+ * The bridge treats this as opaque bytes/object data. Actual inference
+ * adapters interpret the specific shape.
+ *
+ * @public
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Bridge treats payload as opaque
+export type InferencePayload = Record<string, any>
+
+/**
+ * Upstream inference adapter response.
+ *
+ * @public
+ */
+export type InferenceResponse = {
+  /** Request ID this response corresponds to. */
+  requestId: string
+  /** The actual response data (model-specific). */
+  data: InferenceResponseData
+}
+
+/**
+ * Inference response data (model-specific, opaque to the bridge).
+ *
+ * @public
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Bridge treats response as opaque
+export type InferenceResponseData = Record<string, any>
+
+/**
+ * Error from upstream inference adapter.
+ *
+ * @public
+ */
+export type InferenceError = {
+  /** Request ID this error corresponds to. */
+  requestId: string
+  /** Error message. */
+  message: string
+  /** Optional error code. */
+  code?: string
+}
+
+/**
+ * Fakeable upstream inference adapter interface.
+ *
+ * @remarks
+ * The adapter is injected into the bridge, enabling:
+ * - Real inference calls (production)
+ * - Fake/stub responses (testing)
+ * - Mock implementations (eval)
+ *
+ * @public
+ */
+export type InferenceAdapter = {
+  /**
+   * Execute an inference request against the upstream model.
+   *
+   * @param request - The inference request to execute.
+   * @returns The inference response or throws InferenceError.
+   */
+  execute(request: InferenceRequest): Promise<InferenceResponse>
+}
+
+/**
+ * Bridge event types emitted during bridge lifecycle.
+ *
+ * @public
+ */
+export type BridgeEventType = 'inference:request' | 'inference:response' | 'inference:error' | 'inference:policy_seam'
+
+/**
+ * Bridge event envelope for observability.
+ *
+ * @public
+ */
+export type BridgeEvent = {
+  /** Event type discriminator. */
+  type: BridgeEventType
+  /** Timestamp when the event occurred. */
+  timestamp: number
+  /** Request ID this event relates to. */
+  requestId: string
+  /** Event-specific payload. */
+  detail: BridgeEventDetail
+}
+
+/**
+ * Union of all bridge event detail payloads.
+ *
+ * @public
+ */
+export type BridgeEventDetail =
+  | { type: 'inference:request'; request: InferenceRequest }
+  | { type: 'inference:response'; response: InferenceResponse }
+  | { type: 'inference:error'; error: InferenceError }
+  | { type: 'inference:policy_seam'; request: InferenceRequest; allowed: boolean }
+
+/**
+ * BP snapshot record for eval-compatible trajectory mapping.
+ *
+ * @remarks
+ * This is a normalized snapshot record that preserves the BP engine's
+ * state for eval and replay scenarios.
+ *
+ * @public
+ */
+export type BPNormalizedSnapshot = {
+  /** Unique identifier for this snapshot. */
+  snapshotId: string
+  /** Request ID this snapshot relates to. */
+  requestId: string
+  /** Timestamp when the snapshot was taken. */
+  timestamp: number
+  /** Raw BP snapshot message kind. */
+  kind: 'selection' | 'deadlock' | 'feedback_error' | 'extension_error'
+  /** Snapshot data (structure varies by kind). */
+  data: unknown
+}
+
+/**
+ * Trajectory artifact for eval mapping.
+ *
+ * @remarks
+ * Contains all events and snapshots for a complete inference request lifecycle.
+ * This shape is designed for eval-compatible serialization and replay.
+ *
+ * @public
+ */
+export type InferenceTrajectory = {
+  /** Unique trajectory identifier. */
+  trajectoryId: string
+  /** Request ID this trajectory corresponds to. */
+  requestId: string
+  /** All bridge events in order. */
+  events: BridgeEvent[]
+  /** All BP snapshots in order. */
+  snapshots: BPNormalizedSnapshot[]
+  /** Final outcome. */
+  outcome: TrajectoryOutcome
+}
+
+/**
+ * Final outcome of an inference trajectory.
+ *
+ * @public
+ */
+export type TrajectoryOutcome =
+  | { status: 'success'; response: InferenceResponse }
+  | { status: 'error'; error: InferenceError }
+  | { status: 'blocked'; reason: string }
+
+/**
+ * Policy seam extension point for BP-mediated execution.
+ *
+ * @remarks
+ * This is a future extension point where bThreads/extensions can attach
+ * before inference execution. The default policy allows all requests through.
+ *
+ * @public
+ */
+export type InferencePolicy = {
+  /**
+   * Evaluate whether a request should proceed.
+   *
+   * @param request - The inference request to evaluate.
+   * @returns True if the request is allowed, false if blocked.
+   */
+  evaluate(request: InferenceRequest): boolean
+}
+
+/**
+ * Default policy that allows all requests through.
+ *
+ * @public
+ */
+export const defaultInferencePolicy: InferencePolicy = {
+  evaluate: () => true,
+}

--- a/src/inference/tests/inference-bridge.spec.ts
+++ b/src/inference/tests/inference-bridge.spec.ts
@@ -1,0 +1,397 @@
+import { describe, expect, test } from 'bun:test'
+import type { InferenceAdapter, InferencePolicy, InferenceRequest } from '../inference.types.ts'
+import { createInferenceBridge } from '../inference-bridge.ts'
+
+const createTestRequest = (overrides: Partial<InferenceRequest> = {}): InferenceRequest => ({
+  requestId: 'test-req-1',
+  correlationId: 'corr-1',
+  executor: { executorId: 'test-executor', sessionId: 'session-1' },
+  payload: { prompt: 'Hello, world!' },
+  ...overrides,
+})
+
+const createFakeAdapter = (responses: Map<string, { data: Record<string, unknown> } | Error>): InferenceAdapter => ({
+  execute: async (request) => {
+    const response = responses.get(request.requestId)
+    if (!response) {
+      throw new Error(`No mock response for requestId: ${request.requestId}`)
+    }
+    if (response instanceof Error) {
+      throw response
+    }
+    return { requestId: request.requestId, data: response.data }
+  },
+})
+
+describe('inference bridge', () => {
+  describe('pass-through success', () => {
+    test('returns response and trajectory on successful inference', async () => {
+      const adapter = createFakeAdapter(
+        new Map([
+          [
+            'test-req-1',
+            {
+              data: {
+                content: 'Hello back!',
+                model: 'test-model',
+              },
+            },
+          ],
+        ]),
+      )
+
+      const bridge = createInferenceBridge({ adapter })
+      const request = createTestRequest()
+      const result = await bridge.execute(request)
+
+      expect(result.response.requestId).toBe('test-req-1')
+      expect(result.response.data.content).toBe('Hello back!')
+      expect(result.trajectory).toBeDefined()
+      expect(result.trajectory.requestId).toBe('test-req-1')
+      expect(result.trajectory.outcome.status).toBe('success')
+    })
+
+    test('preserves correlationId in request and response', async () => {
+      const adapter = createFakeAdapter(
+        new Map([
+          [
+            'test-req-1',
+            {
+              data: {
+                content: 'Response with correlation',
+              },
+            },
+          ],
+        ]),
+      )
+
+      const bridge = createInferenceBridge({ adapter })
+      const request = createTestRequest({ correlationId: 'my-correlation-id' })
+      const result = await bridge.execute(request)
+
+      expect(result.response.requestId).toBe('test-req-1')
+      expect(result.trajectory.outcome.status).toBe('success')
+    })
+
+    test('emits request and response bridge events', async () => {
+      const adapter = createFakeAdapter(
+        new Map([
+          [
+            'test-req-1',
+            {
+              data: { content: 'test' },
+            },
+          ],
+        ]),
+      )
+
+      const bridge = createInferenceBridge({ adapter })
+      const request = createTestRequest()
+      const result = await bridge.execute(request)
+
+      const eventTypes = result.trajectory.events.map((e) => e.type)
+      expect(eventTypes).toContain('inference:request')
+      expect(eventTypes).toContain('inference:response')
+      expect(eventTypes).toContain('inference:policy_seam')
+    })
+
+    test('captures BP snapshots in trajectory', async () => {
+      const adapter = createFakeAdapter(
+        new Map([
+          [
+            'test-req-1',
+            {
+              data: { content: 'test' },
+            },
+          ],
+        ]),
+      )
+
+      const bridge = createInferenceBridge({ adapter })
+      const request = createTestRequest()
+      const result = await bridge.execute(request)
+
+      // BP snapshots should be captured for policy_seam and response events
+      expect(result.trajectory.snapshots.length).toBeGreaterThan(0)
+      expect(result.trajectory.snapshots.every((s) => s.requestId === 'test-req-1')).toBe(true)
+    })
+  })
+
+  describe('request correlation', () => {
+    test('maintains correct request-response correlation', async () => {
+      const responses = new Map<string, { data: Record<string, unknown> }>([
+        ['req-a', { data: { content: 'Response A' } }],
+        ['req-b', { data: { content: 'Response B' } }],
+        ['req-c', { data: { content: 'Response C' } }],
+      ])
+
+      const adapter = createFakeAdapter(responses)
+      const bridge = createInferenceBridge({ adapter })
+
+      const resultA = await bridge.execute(createTestRequest({ requestId: 'req-a' }))
+      const resultB = await bridge.execute(createTestRequest({ requestId: 'req-b' }))
+      const resultC = await bridge.execute(createTestRequest({ requestId: 'req-c' }))
+
+      expect(resultA.response.data.content).toBe('Response A')
+      expect(resultB.response.data.content).toBe('Response B')
+      expect(resultC.response.data.content).toBe('Response C')
+
+      expect(resultA.trajectory.requestId).toBe('req-a')
+      expect(resultB.trajectory.requestId).toBe('req-b')
+      expect(resultC.trajectory.requestId).toBe('req-c')
+    })
+
+    test('each request gets unique trajectoryId', async () => {
+      const adapter = createFakeAdapter(
+        new Map([
+          ['req-1', { data: { content: 'one' } }],
+          ['req-2', { data: { content: 'two' } }],
+        ]),
+      )
+
+      const bridge = createInferenceBridge({ adapter })
+      const result1 = await bridge.execute(createTestRequest({ requestId: 'req-1' }))
+      const result2 = await bridge.execute(createTestRequest({ requestId: 'req-2' }))
+
+      expect(result1.trajectory.trajectoryId).not.toBe(result2.trajectory.trajectoryId)
+    })
+  })
+
+  describe('policy seam participation', () => {
+    test('default policy allows all requests through', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', { data: { content: 'allowed' } }]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('success')
+    })
+
+    test('policy seam event is emitted', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', { data: { content: 'test' } }]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const request = createTestRequest()
+      const result = await bridge.execute(request)
+
+      const policyEvents = result.trajectory.events.filter((e) => e.type === 'inference:policy_seam')
+      expect(policyEvents.length).toBe(1)
+      expect(policyEvents[0]!.detail).toEqual({
+        type: 'inference:policy_seam',
+        request,
+        allowed: true,
+      })
+    })
+
+    test('custom blocking policy blocks request', async () => {
+      const adapter = createFakeAdapter(new Map([['blocked-req', { data: { content: 'should not see this' } }]]))
+
+      const blockingPolicy: InferencePolicy = {
+        evaluate: (request) => request.requestId !== 'blocked-req',
+      }
+
+      const bridge = createInferenceBridge({ adapter, policy: blockingPolicy })
+      const result = await bridge.execute(createTestRequest({ requestId: 'blocked-req' }))
+
+      expect(result.trajectory.outcome.status).toBe('blocked')
+      if (result.trajectory.outcome.status === 'blocked') {
+        expect(result.trajectory.outcome.reason).toContain('policy evaluation returned false')
+      }
+    })
+
+    test('blocked request does not call adapter', async () => {
+      let adapterCalled = false
+      const adapter: InferenceAdapter = {
+        execute: async () => {
+          adapterCalled = true
+          return { requestId: 'test', data: {} }
+        },
+      }
+
+      const blockingPolicy: InferencePolicy = {
+        evaluate: () => false,
+      }
+
+      const bridge = createInferenceBridge({ adapter, policy: blockingPolicy })
+      await bridge.execute(createTestRequest())
+
+      expect(adapterCalled).toBe(false)
+    })
+
+    test('custom allowing policy allows request through', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', { data: { content: 'allowed by custom policy' } }]]))
+
+      const customPolicy: InferencePolicy = {
+        evaluate: (request) => request.executor.executorId === 'test-executor',
+      }
+
+      const bridge = createInferenceBridge({ adapter, policy: customPolicy })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('success')
+      expect(result.response.data.content).toBe('allowed by custom policy')
+    })
+  })
+
+  describe('upstream failure', () => {
+    test('handles adapter error gracefully', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', new Error('Upstream model unavailable')]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('error')
+      if (result.trajectory.outcome.status === 'error') {
+        expect(result.trajectory.outcome.error.message).toBe('Upstream model unavailable')
+      }
+    })
+
+    test('emits error bridge event on upstream failure', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', new Error('Connection timeout')]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      const errorEvents = result.trajectory.events.filter((e) => e.type === 'inference:error')
+      expect(errorEvents.length).toBe(1)
+      expect(errorEvents[0]!.detail.type).toBe('inference:error')
+      if (errorEvents[0]!.detail.type === 'inference:error') {
+        expect(errorEvents[0]!.detail.error.requestId).toBe('test-req-1')
+        expect(errorEvents[0]!.detail.error.message).toBe('Connection timeout')
+        expect(errorEvents[0]!.detail.error.code).toBe('Error')
+      }
+    })
+
+    test('preserves trajectory on upstream failure', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', new Error('API key invalid')]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.trajectoryId).toBeDefined()
+      expect(result.trajectory.requestId).toBe('test-req-1')
+      expect(result.trajectory.events.length).toBeGreaterThan(0)
+      expect(result.trajectory.snapshots.length).toBeGreaterThan(0)
+    })
+
+    test('captures error code when available', async () => {
+      const customError = new Error('Rate limit exceeded')
+      customError.name = 'RateLimitError'
+
+      const adapter = createFakeAdapter(new Map([['test-req-1', customError]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('error')
+      if (result.trajectory.outcome.status === 'error') {
+        expect(result.trajectory.outcome.error.code).toBe('RateLimitError')
+      }
+    })
+  })
+
+  describe('eval mapping', () => {
+    test('trajectory has required eval-compatible shape', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', { data: { content: 'eval test' } }]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      const { trajectory } = result
+
+      // Required fields for eval compatibility
+      expect(trajectory.trajectoryId).toMatch(/^traj_/)
+      expect(trajectory.requestId).toBe('test-req-1')
+      expect(Array.isArray(trajectory.events)).toBe(true)
+      expect(Array.isArray(trajectory.snapshots)).toBe(true)
+      expect(['success', 'error', 'blocked']).toContain(trajectory.outcome.status)
+    })
+
+    test('snapshot has required eval fields', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', { data: { content: 'snapshot test' } }]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      for (const snapshot of result.trajectory.snapshots) {
+        expect(snapshot.snapshotId).toMatch(/^snap_/)
+        expect(snapshot.requestId).toBe('test-req-1')
+        expect(snapshot.timestamp).toBeGreaterThan(0)
+        expect(['selection', 'deadlock', 'feedback_error', 'extension_error']).toContain(snapshot.kind)
+        expect(snapshot.data).toBeDefined()
+      }
+    })
+
+    test('events have required fields for replay', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', { data: { content: 'replay test' } }]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      for (const event of result.trajectory.events) {
+        expect(event.type).toMatch(/^inference:/)
+        expect(event.timestamp).toBeGreaterThan(0)
+        expect(event.requestId).toBe('test-req-1')
+        expect(event.detail).toBeDefined()
+        expect(event.detail.type).toBe(event.type)
+      }
+    })
+
+    test('success outcome includes response data', async () => {
+      const adapter = createFakeAdapter(
+        new Map([
+          [
+            'test-req-1',
+            {
+              data: {
+                content: 'Success response data',
+                usage: { inputTokens: 10, outputTokens: 20 },
+              },
+            },
+          ],
+        ]),
+      )
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('success')
+      if (result.trajectory.outcome.status === 'success') {
+        expect(result.trajectory.outcome.response.data.content).toBe('Success response data')
+        expect(result.trajectory.outcome.response.data.usage).toEqual({
+          inputTokens: 10,
+          outputTokens: 20,
+        })
+      }
+    })
+
+    test('error outcome includes error details', async () => {
+      const adapter = createFakeAdapter(new Map([['test-req-1', new Error('Model hallucination detected')]]))
+
+      const bridge = createInferenceBridge({ adapter })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('error')
+      if (result.trajectory.outcome.status === 'error') {
+        expect(result.trajectory.outcome.error.requestId).toBe('test-req-1')
+        expect(result.trajectory.outcome.error.message).toBe('Model hallucination detected')
+      }
+    })
+
+    test('blocked outcome includes reason', async () => {
+      const blockingPolicy: InferencePolicy = {
+        evaluate: () => false,
+      }
+
+      const adapter = createFakeAdapter(new Map())
+      const bridge = createInferenceBridge({ adapter, policy: blockingPolicy })
+      const result = await bridge.execute(createTestRequest())
+
+      expect(result.trajectory.outcome.status).toBe('blocked')
+      if (result.trajectory.outcome.status === 'blocked') {
+        expect(typeof result.trajectory.outcome.reason).toBe('string')
+        expect(result.trajectory.outcome.reason.length).toBeGreaterThan(0)
+      }
+    })
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 export * from './agent.ts'
 export * from './behavioral.ts'
+export * from './inference/inference.ts'
 export * from './ui.ts'
 export * from './utils.ts'


### PR DESCRIPTION
## Context

Implement the foundational BP-mediated inference bridge skeleton for Plaited. This is the first step in creating a runtime bridge that routes executor-originated inference traffic through behavioral programming, enabling future policy, MSS, and eval work to attach to real trajectories.

## Summary

Added a new `src/inference/` module implementing the BP-mediated inference bridge with:

- **Types** (`inference.types.ts`): Generic executor-originated inference request type with requestId/correlationId and executor metadata; fakeable upstream adapter interface (InferenceAdapter); bridge event types; BP snapshot normalization; eval-compatible trajectory artifact shape.

- **Schemas** (`inference.schemas.ts`): Zod schemas for all inference bridge types enabling runtime validation.

- **Implementation** (`inference-bridge.ts`): BP-mediated execution using `behavioral()`, `trigger()`, and `useSnapshot()`. Default behavior is transparent/pass-through: no blocking, mutation, redaction, or forked inference. Includes a policy seam (`InferencePolicy`) for future bThread/extension attachment before execution.

- **Tests** (`tests/inference-bridge.spec.ts`): 21 focused Bun tests covering pass-through success, request correlation, policy seam participation, upstream failure, and eval mapping scenarios.

## Changed Files

- `src/inference/inference.types.ts` - Type definitions
- `src/inference/inference.schemas.ts` - Zod schemas  
- `src/inference/inference-bridge.ts` - Bridge implementation
- `src/inference/inference.ts` - Module exports
- `src/inference/tests/inference-bridge.spec.ts` - Tests
- `src/main.ts` - Added inference module export

## Validation

- Targeted tests: `bun test src/inference/tests/inference-bridge.spec.ts` ✅ (21 pass, 0 fail)
- `bun --bun tsc --noEmit` ✅ (exit code 0)
- `bunx biome check --write src/inference/` ✅ (Checked 5 files)

## Known Failures / Drift

None.

## Review Notes / Residual Risks

- The bridge creates a fresh `behavioral()` instance per request. This is intentional for trajectory isolation but may have performance implications for high-throughput scenarios.
- Future work will add actual BP bThreads that participate in the policy seam evaluation.
- MSS dynamic registration is out of scope for this slice.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable (N/A - clean)
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
