### PR TITLE
docs(skills): add plaited-eval and plaited-eval-adapters skill docs

### DIFF
--- a/skills/plaited-eval-adapters/SKILL.md
+++ b/skills/plaited-eval-adapters/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: plaited-eval-adapters
+description: Guide for writing eval-compatible adapter scripts that emit TrialResult artifacts. Use when integrating external agents or scripts into the Plaited eval pipeline.
+license: ISC
+compatibility: Requires bun
+---
+
+# Plaited Eval Adapters
+
+Guide for writing adapter scripts that integrate with the Plaited eval pipeline. External agents and scripts can emit eval-compatible artifacts for use with `bunx plaited eval`.
+
+## When to use
+
+- Integrating an external agent (You.com, OpenRouter, custom) into the eval pipeline
+- Writing a script that wraps a model provider
+- Emitting structured trial results for strategy comparison
+
+## Adapter Interface
+
+An adapter receives `AdapterInput` and must return `AdapterResult`.
+
+### AdapterInput
+
+```typescript
+{
+  /** Single or multi-turn prompt */
+  prompt: string | string[]
+  /** Working directory for the adapter */
+  cwd?: string
+  /** Optional scenario-specific system prompt override */
+  systemPrompt?: string
+}
+```
+
+### AdapterResult
+
+```typescript
+{
+  /** Final agent response text (required) */
+  output: string
+  /** Optional structured trajectory */
+  trajectory?: TrajectoryStep[]
+  /** Optional capture evidence */
+  capture?: CaptureEvidence
+  /** Optional timing information */
+  timing?: Timing
+  /** Process exit code (null if signaled) */
+  exitCode?: number | null
+  /** Whether the adapter timed out */
+  timedOut?: boolean
+}
+```
+
+## Implementation Patterns
+
+### TypeScript module adapter
+
+Export `adapt` as a named function:
+
+```typescript
+// my-adapter.ts
+import type { AdapterInput, AdapterResult } from 'plaited/cli'
+
+export const adapt = async ({
+  prompt,
+  cwd,
+}: AdapterInput): Promise<AdapterResult> => {
+  const start = Date.now()
+  
+  // Call your agent/provider
+  const response = await callMyAgent({
+    prompt: Array.isArray(prompt) ? prompt.join('\n') : prompt,
+    cwd,
+  })
+  
+  return {
+    output: response.text,
+    timing: {
+      total: Date.now() - start,
+      inputTokens: response.inputTokens,
+      outputTokens: response.outputTokens,
+    },
+    trajectory: response.steps.map((step) => ({
+      type: step.type,
+      status: step.status,
+      timestamp: step.timestamp,
+    })),
+    capture: {
+      source: 'my-adapter',
+      format: 'chat-completion',
+      eventCount: response.events.length,
+      messageCount: response.messages.length,
+      toolCallCount: response.toolCalls.length,
+    },
+  }
+}
+```
+
+### Executable adapter
+
+Any executable that reads `AdapterInput` from stdin and emits `AdapterResult` to stdout:
+
+```bash
+#!/bin/bash
+# my-adapter.sh
+
+read -r input
+PROMPT=$(echo "$input" | jq -r '.prompt')
+
+# Call your agent
+RESULT=$(call_my_agent "$PROMPT")
+
+# Emit JSON result
+echo "{\"output\": \"$RESULT\", \"timing\": {\"total\": 1234}}"
+```
+
+## Trajectory Format
+
+Trajectory steps provide structured insight into agent behavior:
+
+```typescript
+{
+  /** Step type: message, tool_call, thought, plan, decision, event */
+  type: string
+  /** Optional status: pending, running, completed, failed */
+  status?: string
+  /** Optional timestamp (ms since epoch) */
+  timestamp?: number
+  // ... additional provider-specific fields preserved
+}
+```
+
+### Common trajectory types
+
+| Type | Description |
+|------|-------------|
+| `message` | User or assistant message |
+| `tool_call` | Tool invocation |
+| `thought` | Reasoning/thinking |
+| `plan` | Execution plan |
+| `decision` | Decision point |
+| `event` | Other events |
+
+## Capture Evidence
+
+Model-agnostic evidence about what was captured during a run:
+
+```typescript
+{
+  /** Adapter or capture source identifier */
+  source: string
+  /** Capture format */
+  format: 'response-only' | 'chat-completion' | 'jsonl-event-stream' | 'mixed'
+  /** Count of provider-native events */
+  eventCount?: number
+  /** Count of user/assistant messages */
+  messageCount?: number
+  /** Count of reasoning/thought segments */
+  thoughtCount?: number
+  /** Count of tool calls */
+  toolCallCount?: number
+  /** Short evidence snippets */
+  snippets?: Array<{
+    kind: 'message' | 'thought' | 'tool_call' | 'event' | 'stderr' | 'stdout' | 'usage'
+    text: string
+  }>
+}
+```
+
+## Usage and Cost Fields
+
+Include timing data for cost analysis:
+
+```typescript
+{
+  timing: {
+    /** Adapter-reported total duration in ms */
+    total?: number
+    /** Input tokens consumed */
+    inputTokens?: number
+    /** Output tokens generated */
+    outputTokens?: number
+  }
+}
+```
+
+## Untrusted Retrieved Content
+
+When adapters include retrieved content in the prompt (RAG, web search, etc.):
+
+1. **Mark retrieved content** in the trajectory
+2. **Include source references** in metadata
+3. **Track retrieval counts** in capture evidence
+
+```typescript
+trajectory: [
+  {
+    type: 'retrieval',
+    status: 'completed',
+    timestamp: Date.now(),
+    source: 'vector-db',
+    docCount: 5,
+  },
+  {
+    type: 'message',
+    role: 'user',
+    content: 'Context: [retrieved docs injected here]',
+    hasRetrievedContent: true,
+  },
+]
+```
+
+## Error Handling
+
+Return a valid result even on failure:
+
+```typescript
+export const adapt = async ({
+  prompt,
+}: AdapterInput): Promise<AdapterResult> => {
+  try {
+    const response = await callAgent(prompt)
+    return { output: response.text }
+  } catch (error) {
+    return {
+      output: '',
+      exitCode: 1,
+      capture: {
+        source: 'my-adapter',
+        format: 'response-only',
+      },
+    }
+  }
+}
+```
+
+## Multi-turn Support
+
+For multi-turn conversations, pass an array of prompts:
+
+```typescript
+export const adapt = async ({
+  prompt,
+}: AdapterInput): Promise<AdapterResult> => {
+  const turns = Array.isArray(prompt) ? prompt : [prompt]
+  let context = ''
+  
+  for (const turn of turns) {
+    const response = await callAgent(context + turn)
+    context += `\nUser: ${turn}\nAssistant: ${response.text}`
+  }
+  
+  return {
+    output: context,
+    trajectory: turns.map((_, i) => ({
+      type: 'message',
+      role: i % 2 === 0 ? 'user' : 'assistant',
+    })),
+  }
+}
+```
+
+## Related Skills
+
+- `plaited-eval` for running the eval CLI and comparing results

--- a/skills/plaited-eval/SKILL.md
+++ b/skills/plaited-eval/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: plaited-eval
+description: Trial runner and strategy comparison CLI for the Plaited framework. Use when running evals against agent adapters, computing pass@k metrics, or comparing two eval runs.
+license: ISC
+compatibility: Requires bun
+---
+
+# Plaited Eval
+
+CLI-first evaluation tooling for running prompt trials against agent adapters and comparing strategy performance.
+
+## When to use
+
+- Running evaluation trials against custom agent adapters
+- Computing pass@k and pass^k metrics with grading
+- Comparing two eval runs (baseline vs challenger)
+- Discovering schema inputs/outputs for the eval pipeline
+
+## Command Discovery
+
+List all available commands:
+
+```bash
+bunx plaited --schema
+```
+
+Discover input/output schemas for a specific command:
+
+```bash
+bunx plaited eval --schema input
+bunx plaited eval --schema output
+bunx plaited compare-trials --schema input
+bunx plaited compare-trials --schema output
+```
+
+## plaited eval
+
+Runs prompts against an adapter k times, optionally grades results, and computes pass@k/pass^k metrics.
+
+### Basic usage
+
+```bash
+# Run eval with prompts from stdin
+echo '{"id":"test-1","input":"Hello"}' | bunx plaited eval '{
+  "adapterPath": "./my-adapter.ts",
+  "k": 1
+}'
+
+# Run eval with prompts from file
+bunx plaited eval '{
+  "adapterPath": "./my-adapter.ts",
+  "promptsPath": "./prompts.jsonl",
+  "outputPath": "./results.jsonl",
+  "k": 3,
+  "concurrency": 2
+}'
+```
+
+### With grading
+
+```bash
+bunx plaited eval '{
+  "adapterPath": "./my-adapter.ts",
+  "promptsPath": "./prompts.jsonl",
+  "graderPath": "./my-grader.ts",
+  "k": 5,
+  "outputPath": "./results.jsonl"
+}'
+```
+
+### Input schema fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `adapterPath` | Yes | Path to adapter script (.ts/.js module or executable) |
+| `promptsPath` | No | Path to prompts.jsonl (default: read from stdin) |
+| `outputPath` | No | Output file path (default: stdout) |
+| `k` | No | Trials per prompt (default: 1) |
+| `graderPath` | No | Path to grader script |
+| `cwd` | No | Working directory for adapter |
+| `timeout` | No | Timeout per prompt in ms (default: 60000) |
+| `concurrency` | No | Concurrent workers (default: 1) |
+| `workspaceDir` | No | Per-prompt workspace isolation base dir |
+| `progress` | No | Show progress to stderr (default: false) |
+| `append` | No | Append to output file (default: false) |
+| `debug` | No | Enable debug mode (default: false) |
+
+## plaited compare-trials
+
+Compares two TrialResult JSONL runs and computes aggregate metrics plus per-prompt deltas with bootstrap confidence intervals.
+
+### Basic usage
+
+```bash
+bunx plaited compare-trials '{
+  "baselinePath": "./baseline-results.jsonl",
+  "challengerPath": "./challenger-results.jsonl"
+}'
+```
+
+### With custom labels and confidence settings
+
+```bash
+bunx plaited compare-trials '{
+  "baselinePath": "./baseline-results.jsonl",
+  "challengerPath": "./challenger-results.jsonl",
+  "baselineLabel": "gpt-4",
+  "challengerLabel": "gpt-4o",
+  "confidence": 0.95,
+  "resamples": 1000
+}'
+```
+
+### Input schema fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `baselinePath` | Yes | - | Path to baseline TrialResult JSONL |
+| `challengerPath` | Yes | - | Path to challenger TrialResult JSONL |
+| `baselineLabel` | No | "baseline" | Label for baseline run |
+| `challengerLabel` | No | "challenger" | Label for challenger run |
+| `confidence` | No | 0.95 | Confidence level for bootstrap CI |
+| `resamples` | No | 1000 | Bootstrap resamples |
+
+### Output structure
+
+The comparison returns:
+- **baseline/challenger run metrics**: avgPassRate, avgPassAtK, avgPassExpK, avgFlakiness, avgDuration, medianDuration, confidence intervals
+- **per-prompt comparison**: individual prompt results with winner
+- **summary**: win counts and totals
+
+## Trial Artifacts
+
+Eval runs produce `TrialResult` objects as JSONL:
+
+```json
+{
+  "id": "prompt-case-id",
+  "input": "The prompt text",
+  "k": 3,
+  "passRate": 0.67,
+  "passAtK": 0.96,
+  "passExpK": 0.30,
+  "trials": [
+    {
+      "trialNum": 1,
+      "output": "Agent response...",
+      "duration": 1234,
+      "pass": true,
+      "score": 0.9,
+      "reasoning": "Correct and complete"
+    }
+  ],
+  "metadata": {}
+}
+```
+
+### Metrics explained
+
+| Metric | Description |
+|--------|-------------|
+| `passRate` | Simple ratio: passes / k |
+| `pass@k` | Probability of at least one pass in k samples |
+| `pass^k` | Probability of all k samples passing |
+| `avgFlakiness` | pass@k - pass^k (indicates non-determinism) |
+
+## Strategy Comparison
+
+Use `compare-trials` to evaluate strategy changes:
+
+1. Run baseline evaluation
+   ```bash
+   bunx plaited eval '{
+     "adapterPath": "./adapters/baseline.ts",
+     "promptsPath": "./prompts.jsonl",
+     "k": 5,
+     "outputPath": "./baseline.jsonl"
+   }'
+   ```
+
+2. Run challenger evaluation
+   ```bash
+   bunx plaited eval '{
+     "adapterPath": "./adapters/challenger.ts",
+     "promptsPath": "./prompts.jsonl",
+     "k": 5,
+     "outputPath": "./challenger.jsonl"
+   }'
+   ```
+
+3. Compare results
+   ```bash
+   bunx plaited compare-trials '{
+     "baselinePath": "./baseline.jsonl",
+     "challengerPath": "./challenger.jsonl",
+     "baselineLabel": "strategy-a",
+     "challengerLabel": "strategy-b"
+   }'
+   ```
+
+## Prompts Format
+
+Prompts are provided as JSONL (newline-delimited JSON):
+
+```jsonl
+{"id": "case-1", "input": "What is 2+2?"}
+{"id": "case-2", "input": "Write a hello world in Python"}
+{"id": "case-3", "input": ["First turn", "Follow up question"], "hint": "Multi-turn"}
+```
+
+### Prompt case fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique test case identifier |
+| `input` | Yes | Prompt text or array of strings for multi-turn |
+| `hint` | No | Grader context hint |
+| `reference` | No | Reference solution |
+| `metadata` | No | Categorization metadata |
+| `timeout` | No | Per-case timeout override (ms) |
+
+## Related Skills
+
+- `plaited-eval-adapters` for writing eval-compatible adapter scripts


### PR DESCRIPTION
Add skill documentation for the Plaited eval CLI tooling (GH-281).

## Changes

- plaited-eval: Documents eval and compare-trials commands, schema discovery, trial artifacts, and strategy comparison workflow
- plaited-eval-adapters: Guides writing eval-compatible adapter scripts with interface documentation and examples

## Validation

- TypeScript compile: bun --bun tsc --noEmit passes
- All examples use bunx plaited for installed package usage (no bun ./bin/plaited.ts)
- Skill structure matches existing patterns (plaited-ui, add-mcp)

Refs #281
