### PR TITLE
docs(skills): rewrite modnet module vocabulary for projection model

### DIFF
--- a/skills/modnet-modules/SKILL.md
+++ b/skills/modnet-modules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: modnet-modules
-description: Modnet/MSS context for module-era Plaited agents. Use when generating or evaluating Bun workspace modules that export modules, mapping MSS semantics onto module behavior, or designing A2A-facing node capability surfaces without widening the minimal core.
+description: MSS vocabulary and module-boundary guidance for agent-owned modules over distributed data and capabilities.
 license: ISC
 compatibility: Requires bun
 ---
@@ -9,21 +9,88 @@ compatibility: Requires bun
 
 ## Purpose
 
-This skill teaches the current modnet translation for Plaited:
+Use this skill when defining, generating, or evaluating module semantics for
+Plaited agents.
 
-- MSS is the semantic and compositional layer
-- A2A is the node entry point and inter-node boundary
-- modules are Bun workspaces
-- modules integrate by exporting modules
-- the agent composes default, deployment-provided, and generated modules
+This skill is about MSS vocabulary and module boundaries, not protocol
+mechanics.
 
-Use this skill for both:
+Core rule:
 
-- generation of candidate module/node modules and bThreads
-- evaluation of candidate module and module-bundle designs
+1. MSS defines what may be projected.
+2. The node runtime enforces whether projection is allowed.
+3. Protocol adapters expose approved projections.
 
-Do not use this skill as proof that older modnet or constitution runtime
-surfaces still exist.
+Projection is semantic/runtime vocabulary. Protocols are mechanics.
+
+Treat A2A, MCP, DID/VC, WebSocket, Streamable HTTP, `postMessage`, and future
+adapters as mechanics, not ontology.
+
+## Current Vocabulary
+
+### MSS
+
+MSS is a coordination and boundary standard for agent-owned modules operating
+over distributed data and capabilities.
+
+The MSS tags below are required vocabulary in this skill:
+
+- `content`
+- `structure`
+- `mechanics`
+- `boundary`
+- `scale`
+
+Use the exact tag names above even when internal schemas remain intentionally
+under-specified.
+
+`scale` must include at least:
+
+- `humanScale`
+- `coordinationScale`
+- `authorityScale`
+- `projectionScale`
+- `relationalScale`
+
+### Module
+
+A module is a user-owned agentic wrapper around a coherent domain of work,
+data, interaction, or life context.
+
+A module gives the agent controlled capability around:
+
+- identity
+- semantics
+- permissions
+- projections
+- allowed integrations
+
+Runtime module realization is:
+
+- MSS envelope
+- module program
+- capability grants
+- projections
+
+### Composition
+
+Skills teach the agent how to do something.
+
+MCP/tools/resources provide access to external capabilities or data.
+
+Modules decide how skills, MCP, tools, UI, data, and behavior compose inside a
+user-owned boundary.
+
+## Module Layers
+
+Treat module design across four explicit layers:
+
+- human-facing: a named capability or workspace the user's agent can manage
+- agent-facing: a semantic wrapper around distributed data, tools, skills, UI,
+  and behavior
+- runtime-facing: MSS envelope plus module program plus capability grants plus
+  projections
+- network-facing: grant-scoped projection, not automatic node inventory
 
 ## Source Texts
 
@@ -33,150 +100,18 @@ and modnet:
 - [references/Structural-IA.md](references/Structural-IA.md)
 - [references/Modnet.md](references/Modnet.md)
 
-Use them as source material, not as direct implementation specs.
+These files are lineage source material only. They are not direct implementation
+specs for current runtime behavior.
+
+If older phrasing appears in those documents (including UI-first modnet framing
+or protocol-specific claims), treat it as historical context.
 
 Current source of truth for runtime behavior lives in:
 
 - `src/agent/*`
-- `src/modules/a2a-module/*`
+- `src/modules/*`
 - issue-backed kernel backlog context in `dev-research/README.md` and linked
   GitHub issues
-
-## Current Translation
-
-### 1. MSS
-
-MSS provides semantic and compositional inputs for modules and artifacts:
-
-- `contentType`
-- `structure`
-- `mechanics`
-- `boundary`
-- `scale`
-
-Use MSS to reason about:
-
-- what a module is for
-- how it should compose with other modules
-- what kind of capability surface it should project
-- what sharing or boundary assumptions are implied
-
-MSS is input context for generation and evaluation. It is not, by itself, a
-runtime loader or policy engine.
-
-### 2. A2A
-
-A2A is the node entry point and node-to-node communication boundary.
-
-Use it to reason about:
-
-- what the node exposes
-- how remote requests enter the system
-- how Agent Card projection should reflect real capabilities
-- how trust, auth, and authority shaping apply at the protocol edge
-
-Do not treat A2A as an internal message bus or a replacement for the local
-behavioral runtime.
-
-### 3. Modules
-
-Modules are Bun workspaces that carry MSS meaning and integrate into agent
-behavior through modules.
-
-The important current translation is:
-
-- a module is not primarily a UI template or legacy modnet package concept
-- a module is a workspace-level unit that can contribute executable modules
-- modules may be shipped, deployment-provided, or generated later
-
-## Concept Translation
-
-The old Structural IA and Modnet texts still matter, but the introduction of a
-personal agent changes how several concepts should be interpreted.
-
-### Personal Agent
-
-The personal agent is now the user's modnet agent:
-
-- it owns the user's local runtime and working context
-- it composes default, deployment-provided, and generated modules
-- it decides how module semantics become behavior
-- it mediates what is exposed beyond the node boundary
-
-This means the user is not primarily interacting with a platform UI or raw
-module template. They are interacting with their agent, which interprets
-modules, renders views, and negotiates capability surfaces.
-
-### Module
-
-Old lineage:
-
-- a self-contained composable unit carrying user-owned content and behavior
-
-Current translation:
-
-- a Bun workspace unit with MSS meaning that can export modules
-- a module may project services, artifacts, or generated views rather than raw
-  internals
-- a module contributes behavior to the agent through module composition
-
-### Network
-
-Old lineage:
-
-- modules or patterns forming larger networks directly, sometimes through
-  proximity or shared template structures
-
-Current translation:
-
-- nodes form networks through A2A
-- modules do not casually self-assemble across node boundaries on their own
-- the agent mediates discovery, translation, sharing, and composition
-
-### Boundary
-
-Old lineage:
-
-- what information a module shares with other modules or networks
-
-Current translation:
-
-- boundary is still a core concept, but now informs:
-  - exposure policy
-  - authority shaping
-  - auth/trust gating
-  - A2A-facing capability projection
-
-### Structure And Mechanics
-
-Old lineage:
-
-- direct information-architecture and interaction-pattern language
-
-Current translation:
-
-- semantic inputs that help the agent decide:
-  - how a module should be rendered or projected
-  - what behavior is coherent for the module
-  - how it composes with other modules
-  - what candidate modules or bThreads make sense
-
-The agent may generate the realization dynamically rather than reusing a fixed
-platform template.
-
-### Sovereignty
-
-Old lineage:
-
-- user-owned modules and user-controlled data outside platform lock-in
-
-Current translation:
-
-- sovereignty centers on the user-owned node and its module/workspace graph
-- the personal agent is the mediator that preserves user control while still
-  exposing selected capabilities over A2A
-- deleting a link or narrowing a boundary should remain more important than any
-  one external platform or consumer
 
 ## Runtime Contract
 
@@ -236,22 +171,26 @@ Evaluation should ask whether a proposal makes those layers clearer or muddier.
 - Keep `src/agent/create-agent.ts` minimal.
 - Put richer node, boundary, and capability behavior into modules.
 - Use MSS to shape capability meaning, not to invent fake runtime subsystems.
-- Use A2A as the node boundary, not as proof that every module must be remotely
-  exposed.
-- Generate modules as Bun workspace units that can export modules.
+- Treat projection as grant-scoped and adapter-agnostic.
+- Do not model modules as traditional installable plugins/packages by default.
+- Do not require any single adapter protocol for module validity.
 - Respect the concrete runtime contract: loadable modules export
   `default: Module[]`.
 - Prefer explicit, reviewable behavior over hidden orchestration doctrine.
-- When drawing on older Structural IA or Modnet concepts, translate them
-  through the personal-agent model before generating code or doctrine.
+- When drawing on older Structural IA or Modnet concepts, treat them as lineage
+  and translate through current module layers.
+- Do not define auth/token storage here; credential/secret actors are future
+  work.
+- Do not introduce full package-layout doctrine in this skill.
 
 ## Evaluation Rubric
 
 When judging a candidate module, node surface, or module bundle, ask:
 
 - does the proposal preserve the minimal core / module split?
-- does the module’s MSS description match its exported behavior?
-- does the A2A-facing surface project real capability rather than internals?
+- does the module's MSS description match its projected behavior?
+- does the network-facing surface expose grant-scoped projections rather than
+  raw internals or automatic inventory?
 - does the design keep boundary, trust, and authority assumptions explicit?
 - does the proposal distinguish default, deployed, and generated modules
   clearly?
@@ -261,6 +200,9 @@ When judging a candidate module, node surface, or module bundle, ask:
 
 Do not assume the repo currently ships:
 
+- modules as mandatory Bun workspace packages
+- A2A as mandatory node entry for all module projections
+- any single transport/protocol as the module ontology
 - old `createNode` / `src/modnet/*` runtime doctrine
 - constitution MAC/DAC runtime layers
 - `protectGovernance`
@@ -287,13 +229,12 @@ Read `references/Modnet.md` when you need:
 After reading them, always translate back into:
 
 - personal modnet agent
-- Bun workspace modules
-- A2A as node boundary
-- module exports as runtime integration
+- agent-owned module boundaries
+- grant-scoped projection
+- runtime integration through current module contracts
 
 ## Related Skills
 
 - **node-auth** — auth implementation seam for sovereign/platform/enterprise/dev
 - **behavioral-core** — BP primitives for deterministic policy
-- **trial-runner** — evaluation flows for candidate module bundles
 - **typescript-lsp** — type-aware analysis of runtime contracts

--- a/skills/modnet-modules/SKILL.md
+++ b/skills/modnet-modules/SKILL.md
@@ -110,8 +110,10 @@ Current source of truth for runtime behavior lives in:
 
 - `src/agent/*`
 - `src/modules/*`
-- issue-backed kernel backlog context in `dev-research/README.md` and linked
-  GitHub issues
+
+Current planning/backlog context lives in:
+
+- `dev-research/README.md` and linked GitHub issues
 
 ## Runtime Contract
 
@@ -188,7 +190,8 @@ Evaluation should ask whether a proposal makes those layers clearer or muddier.
 When judging a candidate module, node surface, or module bundle, ask:
 
 - does the proposal preserve the minimal core / module split?
-- does the module's MSS description match its projected behavior?
+- does the module's MSS description match its module program behavior and
+  approved projections?
 - does the network-facing surface expose grant-scoped projections rather than
   raw internals or automatic inventory?
 - does the design keep boundary, trust, and authority assumptions explicit?
@@ -209,8 +212,8 @@ Do not assume the repo currently ships:
 - `.memory/constitution/` loaders
 - legacy module marketplace or template-registry assumptions
 
-If a proposal needs one of those ideas, treat it as research and route it
-through the relevant issue from `dev-research/README.md`.
+If a proposal needs one of those ideas, treat it as research and open or route
+through a relevant GitHub issue.
 
 ## When To Read The Source Texts
 


### PR DESCRIPTION
## Context

- Refs #296
- Slice 0 docs/skill rewrite to align `skills/modnet-modules/SKILL.md` with current MSS/module vocabulary.

## Summary

- Rewrote the skill around protocol-neutral projection guidance.
- Added explicit required MSS tags: `content`, `structure`, `mechanics`, `boundary`, `scale`.
- Added required `scale` vocabulary: `humanScale`, `coordinationScale`, `authorityScale`, `projectionScale`, `relationalScale`.
- Clarified current module layers: human-facing, agent-facing, runtime-facing, and network-facing.
- Marked `references/Structural-IA.md` and `references/Modnet.md` as lineage-only source material.
- Removed stale guidance that implied modules are Bun workspace packages or that A2A is mandatory.

## Changed Files

- `skills/modnet-modules/SKILL.md`

## Validation

- Targeted tests: skipped (docs/skill-only slice; no executable surfaces changed).
- `bun --bun tsc --noEmit`: skipped (docs/skill-only slice; no TypeScript/runtime changes).
- Manual docs validation: read final skill and confirmed guidance is protocol-neutral and does not treat A2A as mandatory or modules as installable plugins/packages.

## Known Failures / Drift

- None observed in this docs-only slice.

## Review Notes / Residual Risks

- This change updates agent-facing guidance only. Future implementation slices still need to enforce the same vocabulary at runtime admission boundaries.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable (not applicable in docs-only slice)
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
