### PR TITLE
feat(behavioral): add actor kernel envelope schemas

### DIFF
--- a/src/behavioral/behavioral.schemas.ts
+++ b/src/behavioral/behavioral.schemas.ts
@@ -293,7 +293,7 @@ export const ActorEnvelopeSchema = z.object({
   grantId: z.string().optional(),
   correlationId: z.string().optional(),
   causationId: z.string().optional(),
-  detail: z.record(z.string(), z.unknown()).optional(),
+  detail: z.record(z.string(), z.json()).optional(),
   meta: ActorEnvelopeMetaSchema.optional(),
 })
 

--- a/src/behavioral/behavioral.schemas.ts
+++ b/src/behavioral/behavioral.schemas.ts
@@ -231,3 +231,71 @@ export const SnapshotMessageSchema = z.discriminatedUnion('kind', [
 
 /** @public */
 export type SnapshotMessage = z.infer<typeof SnapshotMessageSchema>
+
+/**
+ * Shared actor kinds for behavioral actor-kernel envelopes.
+ *
+ * @public
+ */
+export const ActorKindSchema = z.enum([
+  'module',
+  'ui',
+  'inference',
+  'mcp',
+  'identity',
+  'stream',
+  'execution',
+  'projection',
+  'supervisor',
+])
+
+/** @public */
+export type ActorKind = z.infer<typeof ActorKindSchema>
+
+/**
+ * Serializable reference to an actor participating in a cross-actor exchange.
+ *
+ * @public
+ */
+export const ActorRefSchema = z.object({
+  id: z.string().min(1),
+  kind: ActorKindSchema,
+  moduleId: z.string().optional(),
+})
+
+/** @public */
+export type ActorRef = z.infer<typeof ActorRefSchema>
+
+/**
+ * Optional envelope metadata for intent and routing classification.
+ *
+ * @public
+ */
+export const ActorEnvelopeMetaSchema = z.object({
+  purpose: z.string().optional(),
+  scale: z.string().optional(),
+  boundary: z.string().optional(),
+})
+
+/** @public */
+export type ActorEnvelopeMeta = z.infer<typeof ActorEnvelopeMetaSchema>
+
+/**
+ * Serializable event envelope observed at actor boundaries.
+ *
+ * @public
+ */
+export const ActorEnvelopeSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  source: ActorRefSchema,
+  target: ActorRefSchema.optional(),
+  grantId: z.string().optional(),
+  correlationId: z.string().optional(),
+  causationId: z.string().optional(),
+  detail: z.record(z.string(), z.unknown()).optional(),
+  meta: ActorEnvelopeMetaSchema.optional(),
+})
+
+/** @public */
+export type ActorEnvelope = z.infer<typeof ActorEnvelopeSchema>

--- a/src/behavioral/tests/actor-kernel.schemas.spec.ts
+++ b/src/behavioral/tests/actor-kernel.schemas.spec.ts
@@ -34,4 +34,34 @@ describe('actor kernel schemas', () => {
     expect(required).toEqual(expect.arrayContaining(['id', 'type', 'source']))
     expect(required).toHaveLength(3)
   })
+
+  test('ActorEnvelopeSchema accepts nested JSON detail object values', () => {
+    const parsed = ActorEnvelopeSchema.parse({
+      id: 'env-1',
+      type: 'test_event',
+      source: { id: 'source-1', kind: 'module' },
+      detail: {
+        nested: {
+          ok: true,
+          count: 2,
+          list: ['a', 1, null, { deep: 'value' }],
+        },
+      },
+    })
+
+    expect(parsed.detail?.nested).toBeDefined()
+  })
+
+  test('ActorEnvelopeSchema rejects non-JSON detail values like functions', () => {
+    expect(() =>
+      ActorEnvelopeSchema.parse({
+        id: 'env-2',
+        type: 'test_event',
+        source: { id: 'source-1', kind: 'module' },
+        detail: {
+          fn: () => 'not json',
+        },
+      }),
+    ).toThrow()
+  })
 })

--- a/src/behavioral/tests/actor-kernel.schemas.spec.ts
+++ b/src/behavioral/tests/actor-kernel.schemas.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import * as z from 'zod'
+
+import { ActorEnvelopeSchema, ActorRefSchema } from '../behavioral.schemas.ts'
+
+type JsonSchemaShape = {
+  required?: unknown
+  properties?: Record<string, unknown>
+}
+
+const readRequired = (schema: unknown): string[] => {
+  const required = (schema as JsonSchemaShape).required
+  expect(Array.isArray(required)).toBe(true)
+  return required as string[]
+}
+
+describe('actor kernel schemas', () => {
+  test('ActorRefSchema exports JSON Schema with id and kind as required fields', () => {
+    const schema = z.toJSONSchema(ActorRefSchema)
+    const required = readRequired(schema)
+
+    expect(required).toEqual(expect.arrayContaining(['id', 'kind']))
+    expect(required).toHaveLength(2)
+
+    const kindSchema = (schema as JsonSchemaShape).properties?.kind as { enum?: unknown } | undefined
+    expect(Array.isArray(kindSchema?.enum)).toBe(true)
+    expect(kindSchema?.enum).toContain('projection')
+  })
+
+  test('ActorEnvelopeSchema exports JSON Schema with id, type, and source as required fields', () => {
+    const schema = z.toJSONSchema(ActorEnvelopeSchema)
+    const required = readRequired(schema)
+
+    expect(required).toEqual(expect.arrayContaining(['id', 'type', 'source']))
+    expect(required).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## Context

- Adds the Slice 2 actor-kernel schema skeleton for MSS/module runtime redesign.
- Introduces shared actor reference/envelope vocabulary without runtime routing changes.
- Fixes #300

## Summary

- Added `ActorKindSchema` with actor kinds including `projection`.
- Added `ActorRefSchema` and `ActorEnvelopeSchema` (plus `ActorEnvelopeMetaSchema`) as JSON-Schema-exportable Zod object schemas.
- Kept the change schema-only; no `createAgent`, installer, server-module runtime, UI controller, or inference bridge behavior changes.
- Added focused JSON Schema export tests that assert required fields and `projection` actor kind presence.

## Changed Files

- `src/behavioral/behavioral.schemas.ts`
- `src/behavioral/tests/actor-kernel.schemas.spec.ts`

## Validation

- Targeted tests: `bun test src/behavioral/tests/actor-kernel.schemas.spec.ts` (pass)
- `bun --bun tsc --noEmit`: pass

## Known Failures / Drift

- None observed.

## Review Notes / Residual Risks

- This slice intentionally adds only serializable schema vocabulary.
- Runtime routing/supervisor mediation are intentionally deferred to later slices.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
