### PR TITLE
feat(skills): add plaited-context SQLite substrate

### DIFF
--- a/.agents/skills/plaited-context
+++ b/.agents/skills/plaited-context
@@ -1,0 +1,1 @@
+../../skills/plaited-context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,8 @@ Expand test coverage when the impact is broad, shared, or uncertain.
 **Type over interface** — `type User = {` not `interface User {`
 **No any** — use `unknown` with type guards.
 **PascalCase types** — schemas get `Schema` suffix.
+**CLI schema semantics** — any Zod schema exposed through CLI `--schema input|output` must use
+`.describe(...)` on the top-level schema and meaningful fields so agent consumers get semantic context.
 **Arrow functions** — `const fn = () =>` over `function fn()`.
 **Object params >2 args** — `fn({ a, b, c }: { ... })`.
 **Private fields** — `#field` (ES2022) not `private field`.

--- a/skills/plaited-context/SKILL.md
+++ b/skills/plaited-context/SKILL.md
@@ -10,14 +10,15 @@ compatibility: Requires bun
 ## Purpose
 
 `plaited-context` is a script-first operational context layer for Plaited. It
-indexes source files, docs, skills, and findings into SQLite so follow-on work
-starts from source-grounded evidence instead of memory.
+indexes source files, AGENTS operational instructions, wiki/reference docs,
+skills, and findings into SQLite so follow-on work starts from source-grounded
+evidence instead of memory.
 
 Use it before:
 
 - implementing a feature or fix
 - reviewing a slice or PR
-- updating docs and checking for stale guidance
+- updating wiki/reference docs and checking for stale guidance
 
 ## Operational Context
 
@@ -64,10 +65,10 @@ Override order for DB path:
 bun skills/plaited-context/scripts/init-db.ts '{"dbPath":".plaited/context.sqlite"}'
 ```
 
-2. Scan and index source/docs/skills
+2. Scan and index source/wiki/skills/AGENTS instructions
 
 ```bash
-bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["src","skills","docs"],"force":false}'
+bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","src","skills","docs"],"force":false}'
 ```
 
 3. Assemble task context
@@ -100,6 +101,15 @@ Do not promote guesses into validated findings.
 
 - `candidate` findings may have optional evidence while being triaged.
 - `validated` and `retired` findings must include evidence.
+
+## Source Authority
+
+When sources conflict, prioritize:
+
+1. code in `src/` and other executable sources
+2. `AGENTS.md` operational instructions by scope
+3. skill instructions (`skills/*/SKILL.md`)
+4. wiki/reference docs (for synthesis and background)
 
 ## Script Contracts
 

--- a/skills/plaited-context/SKILL.md
+++ b/skills/plaited-context/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: plaited-context
+description: SQLite-backed Plaited codebase search and context assembly. Use before implementing, reviewing, or updating docs to gather source-grounded files, symbols, patterns, tests, skills, and prior findings.
+license: ISC
+compatibility: Requires bun
+---
+
+# plaited-context
+
+## Purpose
+
+`plaited-context` is a script-first operational context layer for Plaited. It
+indexes source files, docs, skills, and findings into SQLite so follow-on work
+starts from source-grounded evidence instead of memory.
+
+Use it before:
+
+- implementing a feature or fix
+- reviewing a slice or PR
+- updating docs and checking for stale guidance
+
+## Operational Context
+
+The scripts resolve runtime context into one of three modes:
+
+- `repo`: running inside the Plaited source repository
+- `package`: running from a `node_modules/plaited` installation
+- `workspace`: running from another workspace context
+
+The resolver reports:
+
+```ts
+type OperationalContext = {
+  mode: 'repo' | 'package' | 'workspace'
+  cwd: string
+  workspaceRoot: string
+  repoRoot?: string
+  packageRoot?: string
+  nodeHome?: string
+  dbPath: string
+}
+```
+
+Override order for DB path:
+
+1. JSON input `dbPath`
+2. `PLAITED_CONTEXT_DB`
+3. default `.plaited/context.sqlite` under resolved workspace/node-home
+
+`PLAITED_NODE_HOME` is respected. Defaults never target writable paths inside
+`node_modules` package files.
+
+## DB Location Rules
+
+- `assets/` is static shipped material only (`schema.sql`, query templates).
+- Writable DB storage is outside skill assets by default.
+- Recommended default DB location: `.plaited/context.sqlite`.
+
+## Script Workflow
+
+1. Initialize DB
+
+```bash
+bun skills/plaited-context/scripts/init-db.ts '{"dbPath":".plaited/context.sqlite"}'
+```
+
+2. Scan and index source/docs/skills
+
+```bash
+bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["src","skills","docs"],"force":false}'
+```
+
+3. Assemble task context
+
+```bash
+bun skills/plaited-context/scripts/context.ts '{"task":"review module actor diagnostics","mode":"review","paths":["src/modules/example.ts"]}'
+```
+
+4. Run targeted search
+
+```bash
+bun skills/plaited-context/scripts/search.ts '{"query":"useSnapshot reportSnapshot","limit":20}'
+```
+
+5. Record findings with evidence
+
+```bash
+bun skills/plaited-context/scripts/record-finding.ts '{"finding":{"kind":"anti-pattern","status":"candidate","summary":"Internal handlers should not catch ZodError locally.","evidence":[{"path":"src/modules/example.ts","line":100,"symbol":"server_start"}]}}'
+```
+
+6. Export review JSON
+
+```bash
+bun skills/plaited-context/scripts/export-review.ts '{"status":["candidate","validated"],"format":"json"}'
+```
+
+## Evidence Rule
+
+Do not promote guesses into validated findings.
+
+- `candidate` findings may have optional evidence while being triaged.
+- `validated` and `retired` findings must include evidence.
+
+## Script Contracts
+
+All scripts accept one JSON argument and print JSON output. They support schema
+introspection:
+
+```bash
+bun skills/plaited-context/scripts/<script>.ts --schema input
+bun skills/plaited-context/scripts/<script>.ts --schema output
+```
+
+JSON exports are intended for PR and human review workflows.

--- a/skills/plaited-context/assets/queries/README.md
+++ b/skills/plaited-context/assets/queries/README.md
@@ -1,0 +1,15 @@
+# Query Templates
+
+`plaited-context` keeps SQL templates in this directory as static assets.
+
+Slice 0 ships a schema-first substrate. Runtime scripts currently issue
+parameterized SQL directly in TypeScript while this query catalog is kept for
+future expansion (for example: saved search presets, review exports, and
+finding triage views).
+
+Planned template groups:
+
+- file/symbol discovery by path, symbol name, and import edge
+- stale-doc candidate discovery from docs-to-source drift
+- review exports grouped by finding status and module boundary
+- context assembly ranking for review/implement/doc modes

--- a/skills/plaited-context/assets/schema.sql
+++ b/skills/plaited-context/assets/schema.sql
@@ -2,7 +2,7 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS files (
   path TEXT PRIMARY KEY,
-  kind TEXT NOT NULL CHECK (kind IN ('source', 'skill', 'doc', 'other')),
+  kind TEXT NOT NULL CHECK (kind IN ('source', 'skill', 'agent-instructions', 'wiki', 'config', 'other')),
   ext TEXT NOT NULL,
   size_bytes INTEGER NOT NULL,
   mtime_ms INTEGER NOT NULL,
@@ -71,6 +71,17 @@ CREATE TABLE IF NOT EXISTS docs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_docs_indexed_at ON docs(indexed_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_instructions (
+  path TEXT PRIMARY KEY,
+  scope_path TEXT NOT NULL,
+  body TEXT NOT NULL,
+  indexed_at TEXT NOT NULL,
+  FOREIGN KEY (path) REFERENCES files(path) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_instructions_scope ON agent_instructions(scope_path);
+CREATE INDEX IF NOT EXISTS idx_agent_instructions_indexed_at ON agent_instructions(indexed_at DESC);
 
 CREATE TABLE IF NOT EXISTS findings (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/skills/plaited-context/assets/schema.sql
+++ b/skills/plaited-context/assets/schema.sql
@@ -1,0 +1,121 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS files (
+  path TEXT PRIMARY KEY,
+  kind TEXT NOT NULL CHECK (kind IN ('source', 'skill', 'doc', 'other')),
+  ext TEXT NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  mtime_ms INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  indexed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_files_kind ON files(kind);
+CREATE INDEX IF NOT EXISTS idx_files_indexed_at ON files(indexed_at DESC);
+
+CREATE TABLE IF NOT EXISTS symbols (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file_path TEXT NOT NULL,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  line INTEGER NOT NULL,
+  FOREIGN KEY (file_path) REFERENCES files(path) ON DELETE CASCADE,
+  UNIQUE (file_path, name, kind, line)
+);
+
+CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+CREATE INDEX IF NOT EXISTS idx_symbols_file_path ON symbols(file_path);
+
+CREATE TABLE IF NOT EXISTS imports (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file_path TEXT NOT NULL,
+  specifier TEXT NOT NULL,
+  line INTEGER NOT NULL,
+  is_type INTEGER NOT NULL DEFAULT 0 CHECK (is_type IN (0, 1)),
+  FOREIGN KEY (file_path) REFERENCES files(path) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_imports_specifier ON imports(specifier);
+CREATE INDEX IF NOT EXISTS idx_imports_file_path ON imports(file_path);
+
+CREATE TABLE IF NOT EXISTS exports (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file_path TEXT NOT NULL,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  line INTEGER NOT NULL,
+  FOREIGN KEY (file_path) REFERENCES files(path) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_exports_name ON exports(name);
+CREATE INDEX IF NOT EXISTS idx_exports_file_path ON exports(file_path);
+
+CREATE TABLE IF NOT EXISTS skills (
+  path TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  license TEXT,
+  compatibility TEXT,
+  indexed_at TEXT NOT NULL,
+  FOREIGN KEY (path) REFERENCES files(path) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
+
+CREATE TABLE IF NOT EXISTS docs (
+  path TEXT PRIMARY KEY,
+  title TEXT,
+  body TEXT NOT NULL,
+  indexed_at TEXT NOT NULL,
+  FOREIGN KEY (path) REFERENCES files(path) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_docs_indexed_at ON docs(indexed_at DESC);
+
+CREATE TABLE IF NOT EXISTS findings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind TEXT NOT NULL CHECK (kind IN ('pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question')),
+  status TEXT NOT NULL CHECK (status IN ('candidate', 'validated', 'retired')),
+  summary TEXT NOT NULL,
+  details TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_findings_status ON findings(status);
+CREATE INDEX IF NOT EXISTS idx_findings_kind ON findings(kind);
+
+CREATE TABLE IF NOT EXISTS finding_evidence (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  finding_id INTEGER NOT NULL,
+  path TEXT NOT NULL,
+  line INTEGER,
+  symbol TEXT,
+  excerpt TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (finding_id) REFERENCES findings(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_finding_evidence_finding_id ON finding_evidence(finding_id);
+CREATE INDEX IF NOT EXISTS idx_finding_evidence_path ON finding_evidence(path);
+
+CREATE TABLE IF NOT EXISTS context_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  paths_json TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_context_runs_created_at ON context_runs(created_at DESC);
+
+CREATE TRIGGER IF NOT EXISTS trg_findings_updated_at
+AFTER UPDATE ON findings
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+  UPDATE findings
+  SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  WHERE id = NEW.id;
+END;

--- a/skills/plaited-context/assets/schema.sql
+++ b/skills/plaited-context/assets/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS skills (
 CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
 
 CREATE TABLE IF NOT EXISTS docs (
+  -- Stores wiki/reference markdown pages (non-skill, non-AGENTS).
   path TEXT PRIMARY KEY,
   title TEXT,
   body TEXT NOT NULL,

--- a/skills/plaited-context/scripts/context.ts
+++ b/skills/plaited-context/scripts/context.ts
@@ -9,24 +9,28 @@ import {
   resolveOperationalContext,
 } from './plaited-context.ts'
 
-const ContextModeSchema = z.enum(['review', 'implement', 'docs', 'general'])
+const ContextModeSchema = z
+  .enum(['review', 'implement', 'docs', 'general'])
+  .describe('Context assembly mode for review, implementation, or docs work.')
 
 export const ContextInputSchema = OperationalContextOverrideSchema.extend({
-  task: z.string().min(1),
-  mode: ContextModeSchema.default('review'),
-  paths: z.array(z.string().min(1)).default([]),
-})
+  task: z.string().min(1).describe('Task statement to gather context for.'),
+  mode: ContextModeSchema.default('review').describe('How context should be assembled for the task.'),
+  paths: z.array(z.string().min(1)).default([]).describe('Optional target paths to prioritize in context assembly.'),
+}).describe('Input contract for assembling task context from indexed data.')
 
-export const ContextOutputSchema = z.object({
-  ok: z.literal(true),
-  filesToRead: z.array(z.string()),
-  skillsToUse: z.array(z.string()),
-  commandsToRun: z.array(z.string()),
-  knownPatterns: z.array(z.string()),
-  knownAntiPatterns: z.array(z.string()),
-  sourceOfTruth: z.array(z.string()),
-  openQuestions: z.array(z.string()),
-})
+export const ContextOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates context assembly completed successfully.'),
+    filesToRead: z.array(z.string()).describe('Source files to inspect first for this task.'),
+    skillsToUse: z.array(z.string()).describe('Skill names likely relevant to the task.'),
+    commandsToRun: z.array(z.string()).describe('Suggested targeted commands to gather further evidence.'),
+    knownPatterns: z.array(z.string()).describe('Indexed validated patterns relevant to the task.'),
+    knownAntiPatterns: z.array(z.string()).describe('Indexed anti-patterns relevant to the task.'),
+    sourceOfTruth: z.array(z.string()).describe('Ordered high-authority references for decisions.'),
+    openQuestions: z.array(z.string()).describe('Open questions that need direct source confirmation.'),
+  })
+  .describe('Output contract for assembled operational task context.')
 
 export type ContextInput = z.infer<typeof ContextInputSchema>
 export type ContextOutput = z.infer<typeof ContextOutputSchema>

--- a/skills/plaited-context/scripts/context.ts
+++ b/skills/plaited-context/scripts/context.ts
@@ -1,0 +1,75 @@
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  assembleContext,
+  closeContextDatabase,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  recordContextRun,
+  resolveOperationalContext,
+} from './plaited-context.ts'
+
+const ContextModeSchema = z.enum(['review', 'implement', 'docs', 'general'])
+
+export const ContextInputSchema = OperationalContextOverrideSchema.extend({
+  task: z.string().min(1),
+  mode: ContextModeSchema.default('review'),
+  paths: z.array(z.string().min(1)).default([]),
+})
+
+export const ContextOutputSchema = z.object({
+  ok: z.literal(true),
+  filesToRead: z.array(z.string()),
+  skillsToUse: z.array(z.string()),
+  commandsToRun: z.array(z.string()),
+  knownPatterns: z.array(z.string()),
+  knownAntiPatterns: z.array(z.string()),
+  sourceOfTruth: z.array(z.string()),
+  openQuestions: z.array(z.string()),
+})
+
+export type ContextInput = z.infer<typeof ContextInputSchema>
+export type ContextOutput = z.infer<typeof ContextOutputSchema>
+
+export const assembleTaskContext = async (input: ContextInput): Promise<ContextOutput> => {
+  const { task, mode, paths, ...contextOverrides } = input
+  const context = await resolveOperationalContext(contextOverrides)
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+
+  try {
+    const output = assembleContext({
+      db,
+      task,
+      mode,
+      paths,
+    })
+
+    recordContextRun({
+      db,
+      task,
+      mode,
+      paths,
+      result: output,
+    })
+
+    return output
+  } finally {
+    closeContextDatabase(db)
+  }
+}
+
+export const contextCli = makeCli({
+  name: 'skills/plaited-context/scripts/context.ts',
+  inputSchema: ContextInputSchema,
+  outputSchema: ContextOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/context.ts '{"task":"review module actor diagnostics","mode":"review","paths":["src/modules/example.ts"]}'`,
+    `  bun skills/plaited-context/scripts/context.ts --schema output`,
+  ].join('\n'),
+  run: assembleTaskContext,
+})
+
+if (import.meta.main) {
+  await contextCli(Bun.argv.slice(2))
+}

--- a/skills/plaited-context/scripts/export-review.ts
+++ b/skills/plaited-context/scripts/export-review.ts
@@ -10,46 +10,58 @@ import {
   resolveOperationalContext,
 } from './plaited-context.ts'
 
-const ExportedEvidenceSchema = z.object({
-  path: z.string().min(1),
-  line: z.number().int().positive().optional(),
-  symbol: z.string().min(1).optional(),
-  excerpt: z.string().min(1).optional(),
-})
+const ExportedEvidenceSchema = z
+  .object({
+    path: z.string().min(1).describe('Source file path for this evidence row.'),
+    line: z.number().int().positive().optional().describe('Optional 1-based line number.'),
+    symbol: z.string().min(1).optional().describe('Optional symbol tied to evidence.'),
+    excerpt: z.string().min(1).optional().describe('Optional short source excerpt.'),
+  })
+  .describe('Evidence row included in a review export.')
 
-const ExportedFindingSchema = z.object({
-  id: z.number().int().positive(),
-  kind: FindingKindSchema,
-  status: FindingStatusSchema,
-  summary: z.string().min(1),
-  details: z.string().nullable(),
-  createdAt: z.string().min(1),
-  updatedAt: z.string().min(1),
-  evidence: z.array(ExportedEvidenceSchema),
-})
+const ExportedFindingSchema = z
+  .object({
+    id: z.number().int().positive().describe('Finding row id.'),
+    kind: FindingKindSchema.describe('Finding classification.'),
+    status: FindingStatusSchema.describe('Finding lifecycle status.'),
+    summary: z.string().min(1).describe('Short finding summary.'),
+    details: z.string().nullable().describe('Optional long-form details.'),
+    createdAt: z.string().min(1).describe('Creation timestamp in ISO format.'),
+    updatedAt: z.string().min(1).describe('Last update timestamp in ISO format.'),
+    evidence: z.array(ExportedEvidenceSchema).describe('Evidence rows attached to this finding.'),
+  })
+  .describe('Finding row included in a review export.')
 
-const ExportedContextRunSchema = z.object({
-  id: z.number().int().positive(),
-  task: z.string().min(1),
-  mode: z.string().min(1),
-  paths: z.array(z.string()),
-  result: z.unknown().nullable(),
-  createdAt: z.string().min(1),
-})
+const ExportedContextRunSchema = z
+  .object({
+    id: z.number().int().positive().describe('Context run row id.'),
+    task: z.string().min(1).describe('Task string used for context assembly.'),
+    mode: z.string().min(1).describe('Context assembly mode used for the run.'),
+    paths: z.array(z.string()).describe('Input paths used by the run.'),
+    result: z.unknown().nullable().describe('Serialized run output snapshot.'),
+    createdAt: z.string().min(1).describe('Creation timestamp in ISO format.'),
+  })
+  .describe('Recorded context assembly run included in export.')
 
 export const ExportReviewInputSchema = OperationalContextOverrideSchema.extend({
-  status: z.array(FindingStatusSchema).min(1).default(['candidate', 'validated', 'retired']),
-  format: z.enum(['json']).default('json'),
-})
+  status: z
+    .array(FindingStatusSchema)
+    .min(1)
+    .default(['candidate', 'validated', 'retired'])
+    .describe('Finding statuses to include in the export.'),
+  format: z.enum(['json']).default('json').describe('Export format.'),
+}).describe('Input contract for exporting findings and context runs.')
 
-export const ExportReviewOutputSchema = z.object({
-  ok: z.literal(true),
-  format: z.literal('json'),
-  dbPath: z.string().min(1),
-  exportedAt: z.string().min(1),
-  findings: z.array(ExportedFindingSchema),
-  contextRuns: z.array(ExportedContextRunSchema),
-})
+export const ExportReviewOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates export completed successfully.'),
+    format: z.literal('json').describe('Exported output format.'),
+    dbPath: z.string().min(1).describe('Resolved writable SQLite DB path.'),
+    exportedAt: z.string().min(1).describe('Export timestamp in ISO format.'),
+    findings: z.array(ExportedFindingSchema).describe('Exported findings matching selected statuses.'),
+    contextRuns: z.array(ExportedContextRunSchema).describe('Exported context run history.'),
+  })
+  .describe('Output contract for review export.')
 
 export type ExportReviewInput = z.infer<typeof ExportReviewInputSchema>
 export type ExportReviewOutput = z.infer<typeof ExportReviewOutputSchema>

--- a/skills/plaited-context/scripts/export-review.ts
+++ b/skills/plaited-context/scripts/export-review.ts
@@ -1,0 +1,94 @@
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  closeContextDatabase,
+  exportReviewData,
+  FindingKindSchema,
+  FindingStatusSchema,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  resolveOperationalContext,
+} from './plaited-context.ts'
+
+const ExportedEvidenceSchema = z.object({
+  path: z.string().min(1),
+  line: z.number().int().positive().optional(),
+  symbol: z.string().min(1).optional(),
+  excerpt: z.string().min(1).optional(),
+})
+
+const ExportedFindingSchema = z.object({
+  id: z.number().int().positive(),
+  kind: FindingKindSchema,
+  status: FindingStatusSchema,
+  summary: z.string().min(1),
+  details: z.string().nullable(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+  evidence: z.array(ExportedEvidenceSchema),
+})
+
+const ExportedContextRunSchema = z.object({
+  id: z.number().int().positive(),
+  task: z.string().min(1),
+  mode: z.string().min(1),
+  paths: z.array(z.string()),
+  result: z.unknown().nullable(),
+  createdAt: z.string().min(1),
+})
+
+export const ExportReviewInputSchema = OperationalContextOverrideSchema.extend({
+  status: z.array(FindingStatusSchema).min(1).default(['candidate', 'validated', 'retired']),
+  format: z.enum(['json']).default('json'),
+})
+
+export const ExportReviewOutputSchema = z.object({
+  ok: z.literal(true),
+  format: z.literal('json'),
+  dbPath: z.string().min(1),
+  exportedAt: z.string().min(1),
+  findings: z.array(ExportedFindingSchema),
+  contextRuns: z.array(ExportedContextRunSchema),
+})
+
+export type ExportReviewInput = z.infer<typeof ExportReviewInputSchema>
+export type ExportReviewOutput = z.infer<typeof ExportReviewOutputSchema>
+
+export const exportReview = async (input: ExportReviewInput): Promise<ExportReviewOutput> => {
+  const context = await resolveOperationalContext(input)
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+
+  try {
+    const exported = exportReviewData({
+      db,
+      statuses: input.status,
+    })
+
+    return {
+      ok: true,
+      format: 'json',
+      dbPath: context.dbPath,
+      exportedAt: new Date().toISOString(),
+      findings: exported.findings,
+      contextRuns: exported.contextRuns,
+    }
+  } finally {
+    closeContextDatabase(db)
+  }
+}
+
+export const exportReviewCli = makeCli({
+  name: 'skills/plaited-context/scripts/export-review.ts',
+  inputSchema: ExportReviewInputSchema,
+  outputSchema: ExportReviewOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/export-review.ts '{"status":["candidate","validated"],"format":"json"}'`,
+    `  bun skills/plaited-context/scripts/export-review.ts --schema output`,
+  ].join('\n'),
+  run: exportReview,
+})
+
+if (import.meta.main) {
+  await exportReviewCli(Bun.argv.slice(2))
+}

--- a/skills/plaited-context/scripts/init-db.ts
+++ b/skills/plaited-context/scripts/init-db.ts
@@ -8,14 +8,16 @@ import {
 } from './plaited-context.ts'
 
 export const InitDbInputSchema = OperationalContextOverrideSchema.extend({
-  dbPath: z.string().min(1).optional(),
-})
+  dbPath: z.string().min(1).optional().describe('Optional writable SQLite DB path override.'),
+}).describe('Input contract for initializing the plaited-context SQLite database.')
 
-export const InitDbOutputSchema = z.object({
-  ok: z.literal(true),
-  dbPath: z.string().min(1),
-  created: z.boolean(),
-})
+export const InitDbOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates successful initialization.'),
+    dbPath: z.string().min(1).describe('Resolved writable SQLite DB path.'),
+    created: z.boolean().describe('True when the database file did not exist before init.'),
+  })
+  .describe('Output contract for database initialization.')
 
 export type InitDbInput = z.infer<typeof InitDbInputSchema>
 export type InitDbOutput = z.infer<typeof InitDbOutputSchema>

--- a/skills/plaited-context/scripts/init-db.ts
+++ b/skills/plaited-context/scripts/init-db.ts
@@ -1,0 +1,51 @@
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  closeContextDatabase,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  resolveOperationalContext,
+} from './plaited-context.ts'
+
+export const InitDbInputSchema = OperationalContextOverrideSchema.extend({
+  dbPath: z.string().min(1).optional(),
+})
+
+export const InitDbOutputSchema = z.object({
+  ok: z.literal(true),
+  dbPath: z.string().min(1),
+  created: z.boolean(),
+})
+
+export type InitDbInput = z.infer<typeof InitDbInputSchema>
+export type InitDbOutput = z.infer<typeof InitDbOutputSchema>
+
+export const initDb = async (input: InitDbInput): Promise<InitDbOutput> => {
+  const context = await resolveOperationalContext(input)
+  const dbFile = Bun.file(context.dbPath)
+  const existed = await dbFile.exists()
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+  closeContextDatabase(db)
+
+  return {
+    ok: true,
+    dbPath: context.dbPath,
+    created: !existed,
+  }
+}
+
+export const initDbCli = makeCli({
+  name: 'skills/plaited-context/scripts/init-db.ts',
+  inputSchema: InitDbInputSchema,
+  outputSchema: InitDbOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/init-db.ts '{"dbPath":".plaited/context.sqlite"}'`,
+    `  bun skills/plaited-context/scripts/init-db.ts --schema input`,
+  ].join('\n'),
+  run: initDb,
+})
+
+if (import.meta.main) {
+  await initDbCli(Bun.argv.slice(2))
+}

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -1,5 +1,5 @@
 import { Database } from 'bun:sqlite'
-import { mkdir } from 'node:fs/promises'
+import { mkdir, stat } from 'node:fs/promises'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path'
 import { Glob } from 'bun'
 import * as z from 'zod'
@@ -101,7 +101,7 @@ export type FindingInput = z.infer<typeof FindingInputSchema>
 export type FindingEvidenceInput = z.infer<typeof FindingEvidenceSchema>
 
 export type SearchResultEntry = {
-  source: 'file' | 'doc' | 'finding' | 'rg'
+  source: 'file' | 'wiki' | 'finding' | 'rg'
   path?: string
   line?: number
   symbol?: string
@@ -413,7 +413,32 @@ const validateIncludePath = ({ absoluteRoot, includePath }: { absoluteRoot: stri
     throw new Error(`Invalid include path '${includePath}': path escapes rootDir.`)
   }
 
-  const relativeIncludePath = toPosix(relative(absoluteRoot, resolvedIncludePath))
+  return resolvedIncludePath
+}
+
+const getExistingPathType = async (absolutePath: string): Promise<'file' | 'directory' | undefined> => {
+  try {
+    const entry = await stat(absolutePath)
+    if (entry.isFile()) {
+      return 'file'
+    }
+    if (entry.isDirectory()) {
+      return 'directory'
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+const buildIncludeGlobPattern = ({
+  absoluteRoot,
+  absoluteIncludePath,
+}: {
+  absoluteRoot: string
+  absoluteIncludePath: string
+}) => {
+  const relativeIncludePath = toPosix(relative(absoluteRoot, absoluteIncludePath))
   if (relativeIncludePath === '' || relativeIncludePath === '.') {
     return '**/*'
   }
@@ -437,11 +462,24 @@ const collectFilesForIndexing = async ({
       continue
     }
 
-    const globPattern = validateIncludePath({
+    const validatedIncludePath = validateIncludePath({
       absoluteRoot,
       includePath: trimmed,
     })
-    const glob = new Glob(globPattern)
+    const includePathType = await getExistingPathType(validatedIncludePath)
+    if (includePathType === 'file') {
+      if (isSubPath(validatedIncludePath, absoluteRoot) && shouldIndexFile(validatedIncludePath)) {
+        files.add(resolve(validatedIncludePath))
+      }
+      continue
+    }
+
+    const glob = new Glob(
+      buildIncludeGlobPattern({
+        absoluteRoot,
+        absoluteIncludePath: validatedIncludePath,
+      }),
+    )
 
     for await (const foundPath of glob.scan({ cwd: absoluteRoot, absolute: true })) {
       const absoluteFoundPath = resolve(foundPath)
@@ -700,7 +738,7 @@ export const indexWorkspace = async ({
   filesIndexed: number
   symbolsIndexed: number
   skillsIndexed: number
-  docsIndexed: number
+  wikiIndexed: number
 }> => {
   if (force) {
     db.exec('DELETE FROM symbols;')
@@ -770,7 +808,7 @@ export const indexWorkspace = async ({
   let filesIndexed = 0
   let symbolsIndexed = 0
   let skillsIndexed = 0
-  let docsIndexed = 0
+  let wikiIndexed = 0
   const indexedAt = nowIso()
 
   for (const absolutePath of files) {
@@ -831,7 +869,7 @@ export const indexWorkspace = async ({
 
     if (kind === 'wiki') {
       upsertDoc.run(relativePath, parseDocTitle(content) ?? null, content, indexedAt)
-      docsIndexed += 1
+      wikiIndexed += 1
     }
 
     filesIndexed += 1
@@ -841,7 +879,7 @@ export const indexWorkspace = async ({
     filesIndexed,
     symbolsIndexed,
     skillsIndexed,
-    docsIndexed,
+    wikiIndexed,
   }
 }
 
@@ -884,7 +922,7 @@ export const searchContextDatabase = ({
     content: string
   }>
 
-  const docRows = db
+  const wikiRows = db
     .query(
       `SELECT path, body
        FROM docs
@@ -918,8 +956,8 @@ export const searchContextDatabase = ({
       path: row.path,
       snippet: buildSnippet({ text: row.content, query }),
     })),
-    ...docRows.map((row) => ({
-      source: 'doc' as const,
+    ...wikiRows.map((row) => ({
+      source: 'wiki' as const,
       path: row.path,
       snippet: buildSnippet({ text: row.body, query }),
     })),
@@ -1116,7 +1154,7 @@ export const assembleContext = ({
     mode === 'review'
       ? ['bun --bun tsc --noEmit', 'bun test <targeted-files-or-surface>']
       : mode === 'docs'
-        ? ['bun skills/plaited-context/scripts/scan.ts "{"rootDir":".","include":["docs","skills"]}"']
+        ? [`bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","docs","skills"]}'`]
         : [
             'bun --bun tsc --noEmit',
             'bun test <targeted-files-or-surface>',
@@ -1129,7 +1167,8 @@ export const assembleContext = ({
     ...skillPaths,
     'src/ (code)',
     'skills/*/SKILL.md (operational skill instructions)',
-    'docs/ (wiki/reference)',
+    'AGENTS.md (operational instructions)',
+    'docs/ (wiki/reference; lower authority than code, AGENTS.md, and skills)',
   ])
 
   const openQuestions: string[] = []

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -226,31 +226,33 @@ export const resolveOperationalContext = async (
   const explicitWorkspaceRoot = resolveInputPath(cwd, overrides.workspaceRoot)
 
   const scriptPackageRoot = resolve(import.meta.dir, '../../..')
-  const scriptPackageRootIsSourceRepo = await isPlaitedSourceRoot(scriptPackageRoot)
+  const inferredPackageRoot = isInsideNodeModules(scriptPackageRoot) ? scriptPackageRoot : undefined
 
   const detectedRepoRoot = await findUpward({
     start: cwd,
     predicate: isPlaitedSourceRoot,
   })
 
-  const repoRoot =
-    explicitRepoRoot ?? detectedRepoRoot ?? (scriptPackageRootIsSourceRepo ? scriptPackageRoot : undefined)
-
-  const packageRoot = explicitPackageRoot ?? (isInsideNodeModules(scriptPackageRoot) ? scriptPackageRoot : undefined)
+  const repoRoot = explicitRepoRoot ?? detectedRepoRoot
+  const packageRoot = explicitPackageRoot ?? inferredPackageRoot
 
   const mode: OperationalContext['mode'] =
     overrides.mode ??
-    (repoRoot && (isSubPath(cwd, repoRoot) || scriptPackageRootIsSourceRepo)
+    (explicitRepoRoot
       ? 'repo'
-      : packageRoot
-        ? 'package'
-        : 'workspace')
+      : detectedRepoRoot
+        ? 'repo'
+        : explicitPackageRoot
+          ? 'package'
+          : inferredPackageRoot
+            ? 'package'
+            : 'workspace')
 
   let workspaceRoot: string
   if (explicitWorkspaceRoot) {
     workspaceRoot = explicitWorkspaceRoot
-  } else if (mode === 'repo' && repoRoot) {
-    workspaceRoot = repoRoot
+  } else if (mode === 'repo') {
+    workspaceRoot = repoRoot ?? cwd
   } else if (mode === 'package' && packageRoot) {
     workspaceRoot = stripNodeModulesPrefix(packageRoot) ?? (await findWorkspaceRoot(cwd))
   } else {
@@ -365,6 +367,24 @@ const shouldIndexFile = (absolutePath: string): boolean => {
   return TEXT_EXTENSIONS.has(ext)
 }
 
+const validateIncludePath = ({ absoluteRoot, includePath }: { absoluteRoot: string; includePath: string }): string => {
+  if (isAbsolute(includePath)) {
+    throw new Error(`Invalid include path '${includePath}': absolute paths are not allowed.`)
+  }
+
+  const resolvedIncludePath = resolve(absoluteRoot, includePath)
+  if (!isSubPath(resolvedIncludePath, absoluteRoot)) {
+    throw new Error(`Invalid include path '${includePath}': path escapes rootDir.`)
+  }
+
+  const relativeIncludePath = toPosix(relative(absoluteRoot, resolvedIncludePath))
+  if (relativeIncludePath === '' || relativeIncludePath === '.') {
+    return '**/*'
+  }
+
+  return `${relativeIncludePath.replace(/\/+$/, '')}/**/*`
+}
+
 const collectFilesForIndexing = async ({
   rootDir,
   include,
@@ -381,15 +401,23 @@ const collectFilesForIndexing = async ({
       continue
     }
 
-    const normalizedInclude = trimmed.replace(/^\.\//, '').replace(/\/$/, '')
-    const glob = new Glob(`${normalizedInclude}/**/*`)
+    const globPattern = validateIncludePath({
+      absoluteRoot,
+      includePath: trimmed,
+    })
+    const glob = new Glob(globPattern)
 
     for await (const foundPath of glob.scan({ cwd: absoluteRoot, absolute: true })) {
-      if (!shouldIndexFile(foundPath)) {
+      const absoluteFoundPath = resolve(foundPath)
+      if (!isSubPath(absoluteFoundPath, absoluteRoot)) {
         continue
       }
 
-      files.add(resolve(foundPath))
+      if (!shouldIndexFile(absoluteFoundPath)) {
+        continue
+      }
+
+      files.add(absoluteFoundPath)
     }
   }
 

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -3,21 +3,30 @@ import { mkdir } from 'node:fs/promises'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path'
 import { Glob } from 'bun'
 import * as z from 'zod'
-import { parseMarkdownWithFrontmatter } from '../../../src/cli.ts'
+import {
+  findSkillDirectories,
+  getSkillInstructionResourceLinks,
+  loadSkillCatalog,
+  loadSkillFrontmatter,
+  loadSkillInstructions,
+} from '../../../src/cli.ts'
 
 const DEFAULT_DB_RELATIVE_PATH = '.plaited/context.sqlite'
 const SCHEMA_SQL_PATH = resolve(import.meta.dir, '../assets/schema.sql')
-const SKILL_FRONTMATTER_SCHEMA = z
-  .object({
-    name: z.string().min(1),
-    description: z.string().min(1),
-    license: z.string().min(1).optional(),
-    compatibility: z.string().min(1).optional(),
-  })
-  .passthrough()
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'])
-const TEXT_EXTENSIONS = new Set([...SOURCE_EXTENSIONS, '.md', '.json', '.jsonc', '.yaml', '.yml'])
+const CONFIG_EXTENSIONS = new Set(['.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.cfg', '.conf'])
+const TEXT_EXTENSIONS = new Set([...SOURCE_EXTENSIONS, '.md', ...CONFIG_EXTENSIONS])
+const CONFIG_BASENAMES = new Set([
+  'package.json',
+  'tsconfig.json',
+  'biome.json',
+  'biome.jsonc',
+  'bunfig.toml',
+  '.env',
+  '.env.example',
+  '.env.schema',
+])
 
 const SYMBOL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
   { kind: 'function', pattern: /\b(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/ },
@@ -34,43 +43,55 @@ const EXPORT_DECLARATION_PATTERN =
   /\bexport\s+(?:default\s+)?(?:async\s+)?(function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][\w$]*)/g
 const EXPORT_NAMED_PATTERN = /\bexport\s*\{([^}]+)\}/g
 
-export const FindingStatusSchema = z.enum(['candidate', 'validated', 'retired'])
-export const FindingKindSchema = z.enum(['pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question'])
+export const FindingStatusSchema = z
+  .enum(['candidate', 'validated', 'retired'])
+  .describe('Lifecycle status for a recorded finding.')
+export const FindingKindSchema = z
+  .enum(['pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question'])
+  .describe('Classification for a recorded finding.')
 
-export const OperationalContextSchema = z.object({
-  mode: z.enum(['repo', 'package', 'workspace']),
-  cwd: z.string(),
-  workspaceRoot: z.string(),
-  repoRoot: z.string().optional(),
-  packageRoot: z.string().optional(),
-  nodeHome: z.string().optional(),
-  dbPath: z.string(),
-})
+export const OperationalContextSchema = z
+  .object({
+    mode: z.enum(['repo', 'package', 'workspace']).describe('Resolved operating mode for context lookup.'),
+    cwd: z.string().describe('Working directory used for resolution and relative paths.'),
+    workspaceRoot: z.string().describe('Resolved workspace root used for local defaults.'),
+    repoRoot: z.string().optional().describe('Resolved Plaited source repo root when operating in repo mode.'),
+    packageRoot: z.string().optional().describe('Resolved installed package root when operating in package mode.'),
+    nodeHome: z.string().optional().describe('Optional node home used for writable local state defaults.'),
+    dbPath: z.string().describe('Resolved writable SQLite database path for plaited-context.'),
+  })
+  .describe('Fully resolved operational context for plaited-context scripts.')
 
-export const OperationalContextOverrideSchema = z.object({
-  mode: OperationalContextSchema.shape.mode.optional(),
-  cwd: z.string().min(1).optional(),
-  workspaceRoot: z.string().min(1).optional(),
-  repoRoot: z.string().min(1).optional(),
-  packageRoot: z.string().min(1).optional(),
-  nodeHome: z.string().min(1).optional(),
-  dbPath: z.string().min(1).optional(),
-})
+export const OperationalContextOverrideSchema = z
+  .object({
+    mode: OperationalContextSchema.shape.mode.optional().describe('Optional explicit mode override.'),
+    cwd: z.string().min(1).optional().describe('Optional working directory override.'),
+    workspaceRoot: z.string().min(1).optional().describe('Optional workspace root override.'),
+    repoRoot: z.string().min(1).optional().describe('Optional explicit repo root override.'),
+    packageRoot: z.string().min(1).optional().describe('Optional explicit package root override.'),
+    nodeHome: z.string().min(1).optional().describe('Optional node home for writable local state.'),
+    dbPath: z.string().min(1).optional().describe('Optional explicit SQLite DB path override.'),
+  })
+  .describe('Optional operational context overrides accepted by all plaited-context scripts.')
 
-export const FindingEvidenceSchema = z.object({
-  path: z.string().min(1),
-  line: z.number().int().positive().optional(),
-  symbol: z.string().min(1).optional(),
-  excerpt: z.string().min(1).optional(),
-})
+export const FindingEvidenceSchema = z
+  .object({
+    path: z.string().min(1).describe('Source file path supporting the finding.'),
+    line: z.number().int().positive().optional().describe('1-based line number for the evidence location.'),
+    symbol: z.string().min(1).optional().describe('Optional symbol name tied to the evidence.'),
+    excerpt: z.string().min(1).optional().describe('Optional short source excerpt for review context.'),
+  })
+  .describe('Source-grounded evidence attached to a finding.')
 
-export const FindingInputSchema = z.object({
-  kind: FindingKindSchema,
-  status: FindingStatusSchema,
-  summary: z.string().min(1),
-  details: z.string().optional(),
-  evidence: z.array(FindingEvidenceSchema).default([]),
-})
+export const FindingInputSchema = z
+  .object({
+    kind: FindingKindSchema.describe('Finding category.'),
+    status: FindingStatusSchema.describe('Initial lifecycle status.'),
+    summary: z.string().min(1).describe('Short reviewer-facing finding statement.'),
+    details: z.string().optional().describe('Optional longer rationale or context.'),
+    evidence: z.array(FindingEvidenceSchema).default([]).describe('Evidence entries supporting the finding.'),
+  })
+  .describe('Finding payload accepted by record-finding script.')
 
 export type OperationalContext = z.infer<typeof OperationalContextSchema>
 export type OperationalContextOverrides = z.infer<typeof OperationalContextOverrideSchema>
@@ -342,17 +363,32 @@ const createLineResolver = (source: string) => {
   }
 }
 
-const classifyFileKind = (relativePath: string): 'source' | 'skill' | 'doc' | 'other' => {
-  if (relativePath.endsWith('/SKILL.md') || relativePath === 'SKILL.md') {
+const classifyFileKind = (
+  relativePath: string,
+): 'source' | 'skill' | 'agent-instructions' | 'wiki' | 'config' | 'other' => {
+  const normalizedPath = toPosix(relativePath)
+  const filename = basename(normalizedPath)
+  const lowerFilename = filename.toLowerCase()
+
+  if (filename === 'AGENTS.md') {
+    return 'agent-instructions'
+  }
+
+  if (filename === 'SKILL.md') {
     return 'skill'
   }
 
-  if (relativePath.endsWith('.md')) {
-    return 'doc'
+  const extension = extname(normalizedPath).toLowerCase()
+  if (SOURCE_EXTENSIONS.has(extension)) {
+    return 'source'
   }
 
-  if (SOURCE_EXTENSIONS.has(extname(relativePath).toLowerCase())) {
-    return 'source'
+  if (extension === '.md') {
+    return 'wiki'
+  }
+
+  if (CONFIG_EXTENSIONS.has(extension) || CONFIG_BASENAMES.has(lowerFilename)) {
+    return 'config'
   }
 
   return 'other'
@@ -579,32 +615,70 @@ const parseExports = (source: string): ExportRow[] => {
   return exports
 }
 
-const parseSkillFrontmatter = ({
-  path,
-  markdown,
-}: {
-  path: string
-  markdown: string
-}): {
+type SkillIndexEntry = {
   name: string
   description: string
-  license?: string
-  compatibility?: string
-} => {
-  try {
-    const { frontmatter } = parseMarkdownWithFrontmatter(markdown, SKILL_FRONTMATTER_SCHEMA)
-    return {
-      name: frontmatter.name,
-      description: frontmatter.description,
-      license: frontmatter.license,
-      compatibility: frontmatter.compatibility,
-    }
-  } catch {
-    return {
-      name: basename(dirname(path)),
-      description: 'Skill frontmatter failed to parse during scan.',
-    }
+  license: string | null
+  compatibility: string | null
+}
+
+const getStringRecordField = (record: Record<string, unknown> | undefined, key: string): string | undefined => {
+  if (!record) {
+    return undefined
   }
+
+  const value = record[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+}
+
+const loadSkillIndex = async ({ rootDir }: { rootDir: string }): Promise<Map<string, SkillIndexEntry>> => {
+  const skillIndex = new Map<string, SkillIndexEntry>()
+  const [skillDirectories, skillCatalog] = await Promise.all([findSkillDirectories(rootDir), loadSkillCatalog(rootDir)])
+  const catalogByPath = new Map(skillCatalog.catalog.map((entry) => [entry.path, entry]))
+
+  for (const skillDirectory of skillDirectories) {
+    const relativeSkillDirectory = toPosix(relative(rootDir, skillDirectory))
+    if (!relativeSkillDirectory || relativeSkillDirectory === '.' || relativeSkillDirectory.startsWith('../')) {
+      continue
+    }
+
+    const relativeSkillPath = toPosix(join(relativeSkillDirectory, 'SKILL.md'))
+    const catalogEntry = catalogByPath.get(`/${relativeSkillPath}`)
+    if (!catalogEntry) {
+      continue
+    }
+
+    const [frontmatter, instructions, linkValidation] = await Promise.all([
+      loadSkillFrontmatter(rootDir, relativeSkillDirectory),
+      loadSkillInstructions(rootDir, relativeSkillDirectory),
+      getSkillInstructionResourceLinks(rootDir, relativeSkillDirectory),
+    ])
+    if (!instructions) {
+      continue
+    }
+    if (!linkValidation || linkValidation.errors.length > 0) {
+      continue
+    }
+
+    skillIndex.set(relativeSkillPath, {
+      name: getStringRecordField(frontmatter, 'name') ?? catalogEntry.name,
+      description: getStringRecordField(frontmatter, 'description') ?? catalogEntry.description,
+      license: getStringRecordField(frontmatter, 'license') ?? null,
+      compatibility: getStringRecordField(frontmatter, 'compatibility') ?? null,
+    })
+  }
+
+  return skillIndex
+}
+
+const toAgentInstructionScopePath = (relativePath: string): string => {
+  const normalizedPath = toPosix(relativePath)
+  if (normalizedPath === 'AGENTS.md') {
+    return '.'
+  }
+
+  const directory = toPosix(dirname(normalizedPath))
+  return directory === '.' ? '.' : directory
 }
 
 const parseDocTitle = (markdown: string): string | undefined => {
@@ -632,13 +706,17 @@ export const indexWorkspace = async ({
     db.exec('DELETE FROM symbols;')
     db.exec('DELETE FROM imports;')
     db.exec('DELETE FROM exports;')
+    db.exec('DELETE FROM agent_instructions;')
     db.exec('DELETE FROM skills;')
     db.exec('DELETE FROM docs;')
     db.exec('DELETE FROM files;')
   }
 
   const absoluteRoot = resolve(rootDir)
-  const files = await collectFilesForIndexing({ rootDir: absoluteRoot, include })
+  const [files, skillIndex] = await Promise.all([
+    collectFilesForIndexing({ rootDir: absoluteRoot, include }),
+    loadSkillIndex({ rootDir: absoluteRoot }),
+  ])
 
   const upsertFile = db.query(
     `INSERT INTO files (path, kind, ext, size_bytes, mtime_ms, content, indexed_at)
@@ -655,6 +733,7 @@ export const indexWorkspace = async ({
   const deleteFileSymbols = db.query('DELETE FROM symbols WHERE file_path = ?')
   const deleteFileImports = db.query('DELETE FROM imports WHERE file_path = ?')
   const deleteFileExports = db.query('DELETE FROM exports WHERE file_path = ?')
+  const deleteFileAgentInstructions = db.query('DELETE FROM agent_instructions WHERE path = ?')
   const deleteFileSkill = db.query('DELETE FROM skills WHERE path = ?')
   const deleteFileDoc = db.query('DELETE FROM docs WHERE path = ?')
 
@@ -676,6 +755,14 @@ export const indexWorkspace = async ({
      VALUES (?, ?, ?, ?)
      ON CONFLICT(path) DO UPDATE SET
        title = excluded.title,
+       body = excluded.body,
+       indexed_at = excluded.indexed_at`,
+  )
+  const upsertAgentInstruction = db.query(
+    `INSERT INTO agent_instructions (path, scope_path, body, indexed_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       scope_path = excluded.scope_path,
        body = excluded.body,
        indexed_at = excluded.indexed_at`,
   )
@@ -702,6 +789,7 @@ export const indexWorkspace = async ({
     deleteFileSymbols.run(relativePath)
     deleteFileImports.run(relativePath)
     deleteFileExports.run(relativePath)
+    deleteFileAgentInstructions.run(relativePath)
     deleteFileSkill.run(relativePath)
     deleteFileDoc.run(relativePath)
 
@@ -723,23 +811,25 @@ export const indexWorkspace = async ({
     }
 
     if (kind === 'skill') {
-      const skillMeta = parseSkillFrontmatter({
-        path: relativePath,
-        markdown: content,
-      })
-
-      upsertSkill.run(
-        relativePath,
-        skillMeta.name,
-        skillMeta.description,
-        skillMeta.license ?? null,
-        skillMeta.compatibility ?? null,
-        indexedAt,
-      )
-      skillsIndexed += 1
+      const skillMeta = skillIndex.get(relativePath)
+      if (skillMeta) {
+        upsertSkill.run(
+          relativePath,
+          skillMeta.name,
+          skillMeta.description,
+          skillMeta.license,
+          skillMeta.compatibility,
+          indexedAt,
+        )
+        skillsIndexed += 1
+      }
     }
 
-    if (kind === 'doc' || kind === 'skill') {
+    if (kind === 'agent-instructions') {
+      upsertAgentInstruction.run(relativePath, toAgentInstructionScopePath(relativePath), content, indexedAt)
+    }
+
+    if (kind === 'wiki') {
       upsertDoc.run(relativePath, parseDocTitle(content) ?? null, content, indexedAt)
       docsIndexed += 1
     }
@@ -906,6 +996,33 @@ const splitQueryTerms = (task: string): string[] => {
 }
 
 const unique = (items: string[]): string[] => [...new Set(items)]
+const normalizeRelativePath = (value: string): string => toPosix(value).replace(/^\.\//, '').replace(/\/+$/, '')
+const pathScopesOverlap = (left: string, right: string): boolean =>
+  left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`)
+
+const getRelevantAgentInstructionPaths = ({
+  rows,
+  paths,
+}: {
+  rows: Array<{ path: string; scope_path: string }>
+  paths: string[]
+}): string[] => {
+  if (paths.length === 0) {
+    return rows.map((row) => row.path)
+  }
+
+  const normalizedTaskPaths = paths.map((path) => normalizeRelativePath(path)).filter((path) => path.length > 0)
+  return rows
+    .filter((row) => {
+      if (row.scope_path === '.') {
+        return true
+      }
+
+      return normalizedTaskPaths.some((path) => pathScopesOverlap(path, normalizeRelativePath(row.scope_path)))
+    })
+    .map((row) => row.path)
+}
+
 const safeParseJson = (value: string): unknown | null => {
   try {
     return JSON.parse(value)
@@ -949,21 +1066,31 @@ export const assembleContext = ({
   }
 
   const skillRows = new Set<string>()
+  const skillPaths = new Set<string>()
   for (const term of searchTerms) {
     const likePattern = `%${escapeLike(term)}%`
     const matches = db
       .query(
-        `SELECT name
+        `SELECT name, path
          FROM skills
          WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE OR description LIKE ? ESCAPE '\\' COLLATE NOCASE
          ORDER BY name ASC
          LIMIT 8`,
       )
-      .all(likePattern, likePattern) as Array<{ name: string }>
+      .all(likePattern, likePattern) as Array<{ name: string; path: string }>
     for (const match of matches) {
       skillRows.add(match.name)
+      skillPaths.add(match.path)
     }
   }
+
+  const agentInstructionRows = db
+    .query(
+      `SELECT path, scope_path
+       FROM agent_instructions
+       ORDER BY CASE scope_path WHEN '.' THEN 0 ELSE 1 END, LENGTH(scope_path) DESC, path ASC`,
+    )
+    .all() as Array<{ path: string; scope_path: string }>
 
   const findingPatternRows = db
     .query(
@@ -996,7 +1123,14 @@ export const assembleContext = ({
             'bun skills/plaited-context/scripts/search.ts',
           ]
 
-  const sourceOfTruth = unique(['AGENTS.md', ...paths, 'src/', 'skills/', 'docs/'])
+  const sourceOfTruth = unique([
+    ...paths,
+    ...getRelevantAgentInstructionPaths({ rows: agentInstructionRows, paths }),
+    ...skillPaths,
+    'src/ (code)',
+    'skills/*/SKILL.md (operational skill instructions)',
+    'docs/ (wiki/reference)',
+  ])
 
   const openQuestions: string[] = []
   if (filesToRead.size === 0) {

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -1,0 +1,1188 @@
+import { Database } from 'bun:sqlite'
+import { mkdir } from 'node:fs/promises'
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path'
+import { Glob } from 'bun'
+import * as z from 'zod'
+import { parseMarkdownWithFrontmatter } from '../../../src/cli.ts'
+
+const DEFAULT_DB_RELATIVE_PATH = '.plaited/context.sqlite'
+const SCHEMA_SQL_PATH = resolve(import.meta.dir, '../assets/schema.sql')
+const SKILL_FRONTMATTER_SCHEMA = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().min(1),
+    license: z.string().min(1).optional(),
+    compatibility: z.string().min(1).optional(),
+  })
+  .passthrough()
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'])
+const TEXT_EXTENSIONS = new Set([...SOURCE_EXTENSIONS, '.md', '.json', '.jsonc', '.yaml', '.yml'])
+
+const SYMBOL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
+  { kind: 'function', pattern: /\b(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/ },
+  { kind: 'const', pattern: /\b(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)/ },
+  { kind: 'class', pattern: /\b(?:export\s+)?(?:default\s+)?class\s+([A-Za-z_$][\w$]*)/ },
+  { kind: 'type', pattern: /\b(?:export\s+)?type\s+([A-Za-z_$][\w$]*)/ },
+  { kind: 'interface', pattern: /\b(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)/ },
+  { kind: 'enum', pattern: /\b(?:export\s+)?enum\s+([A-Za-z_$][\w$]*)/ },
+]
+
+const IMPORT_PATTERN = /\bimport(?:\s+type)?(?:[\s\w*{},]*?\sfrom\s*)?['"]([^'"]+)['"]/g
+const EXPORT_FROM_PATTERN = /\bexport(?:\s+type)?[\s\w*{},]*?\sfrom\s*['"]([^'"]+)['"]/g
+const EXPORT_DECLARATION_PATTERN =
+  /\bexport\s+(?:default\s+)?(?:async\s+)?(function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][\w$]*)/g
+const EXPORT_NAMED_PATTERN = /\bexport\s*\{([^}]+)\}/g
+
+export const FindingStatusSchema = z.enum(['candidate', 'validated', 'retired'])
+export const FindingKindSchema = z.enum(['pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question'])
+
+export const OperationalContextSchema = z.object({
+  mode: z.enum(['repo', 'package', 'workspace']),
+  cwd: z.string(),
+  workspaceRoot: z.string(),
+  repoRoot: z.string().optional(),
+  packageRoot: z.string().optional(),
+  nodeHome: z.string().optional(),
+  dbPath: z.string(),
+})
+
+export const OperationalContextOverrideSchema = z.object({
+  mode: OperationalContextSchema.shape.mode.optional(),
+  cwd: z.string().min(1).optional(),
+  workspaceRoot: z.string().min(1).optional(),
+  repoRoot: z.string().min(1).optional(),
+  packageRoot: z.string().min(1).optional(),
+  nodeHome: z.string().min(1).optional(),
+  dbPath: z.string().min(1).optional(),
+})
+
+export const FindingEvidenceSchema = z.object({
+  path: z.string().min(1),
+  line: z.number().int().positive().optional(),
+  symbol: z.string().min(1).optional(),
+  excerpt: z.string().min(1).optional(),
+})
+
+export const FindingInputSchema = z.object({
+  kind: FindingKindSchema,
+  status: FindingStatusSchema,
+  summary: z.string().min(1),
+  details: z.string().optional(),
+  evidence: z.array(FindingEvidenceSchema).default([]),
+})
+
+export type OperationalContext = z.infer<typeof OperationalContextSchema>
+export type OperationalContextOverrides = z.infer<typeof OperationalContextOverrideSchema>
+export type FindingStatus = z.infer<typeof FindingStatusSchema>
+export type FindingKind = z.infer<typeof FindingKindSchema>
+export type FindingInput = z.infer<typeof FindingInputSchema>
+export type FindingEvidenceInput = z.infer<typeof FindingEvidenceSchema>
+
+export type SearchResultEntry = {
+  source: 'file' | 'doc' | 'finding' | 'rg'
+  path?: string
+  line?: number
+  symbol?: string
+  findingId?: number
+  status?: FindingStatus
+  kind?: FindingKind
+  summary?: string
+  snippet: string
+}
+
+export type ContextAssemblyOutput = {
+  ok: true
+  filesToRead: string[]
+  skillsToUse: string[]
+  commandsToRun: string[]
+  knownPatterns: string[]
+  knownAntiPatterns: string[]
+  sourceOfTruth: string[]
+  openQuestions: string[]
+}
+
+type SymbolRow = {
+  name: string
+  kind: string
+  line: number
+}
+
+type ImportRow = {
+  specifier: string
+  line: number
+  isType: boolean
+}
+
+type ExportRow = {
+  name: string
+  kind: string
+  line: number
+}
+
+let cachedSchemaSql: string | undefined
+
+const nowIso = () => new Date().toISOString()
+
+const toPosix = (value: string) => value.replace(/\\/g, '/')
+
+const isInsideNodeModules = (value: string) => toPosix(value).includes('/node_modules/')
+
+const stripNodeModulesPrefix = (value: string): string | undefined => {
+  const normalized = toPosix(resolve(value))
+  const marker = '/node_modules/'
+  const markerIndex = normalized.indexOf(marker)
+  if (markerIndex === -1) {
+    return undefined
+  }
+
+  return normalized.slice(0, markerIndex)
+}
+
+const resolveInputPath = (cwd: string, value?: string): string | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  return isAbsolute(value) ? value : resolve(cwd, value)
+}
+
+const isSubPath = (candidate: string, rootPath: string): boolean => {
+  const relativePath = relative(rootPath, candidate)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+const readPackageName = async (directory: string): Promise<string | undefined> => {
+  const packageJsonPath = join(directory, 'package.json')
+  const packageJsonFile = Bun.file(packageJsonPath)
+  if (!(await packageJsonFile.exists())) {
+    return undefined
+  }
+
+  try {
+    const parsed = await packageJsonFile.json()
+    const maybeName =
+      typeof parsed === 'object' && parsed !== null && 'name' in parsed
+        ? (parsed as { name?: unknown }).name
+        : undefined
+    return typeof maybeName === 'string' ? maybeName : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const isPlaitedSourceRoot = async (directory: string): Promise<boolean> => {
+  const agentsFile = Bun.file(join(directory, 'AGENTS.md'))
+  if (!(await agentsFile.exists())) {
+    return false
+  }
+
+  return (await readPackageName(directory)) === 'plaited'
+}
+
+const findUpward = async ({
+  start,
+  predicate,
+}: {
+  start: string
+  predicate: (directory: string) => Promise<boolean>
+}): Promise<string | undefined> => {
+  let current = resolve(start)
+
+  while (true) {
+    if (await predicate(current)) {
+      return current
+    }
+
+    const parent = dirname(current)
+    if (parent === current) {
+      return undefined
+    }
+
+    current = parent
+  }
+}
+
+const findWorkspaceRoot = async (cwd: string): Promise<string> => {
+  const nodeModulesRoot = stripNodeModulesPrefix(cwd)
+  if (nodeModulesRoot) {
+    return nodeModulesRoot
+  }
+
+  const nearestPackageRoot = await findUpward({
+    start: cwd,
+    predicate: async (directory) => Bun.file(join(directory, 'package.json')).exists(),
+  })
+
+  return nearestPackageRoot ?? cwd
+}
+
+export const resolveOperationalContext = async (
+  overrides: OperationalContextOverrides = {},
+): Promise<OperationalContext> => {
+  const cwd = resolve(overrides.cwd ?? process.cwd())
+  const explicitRepoRoot = resolveInputPath(cwd, overrides.repoRoot)
+  const explicitPackageRoot = resolveInputPath(cwd, overrides.packageRoot)
+  const explicitWorkspaceRoot = resolveInputPath(cwd, overrides.workspaceRoot)
+
+  const scriptPackageRoot = resolve(import.meta.dir, '../../..')
+  const scriptPackageRootIsSourceRepo = await isPlaitedSourceRoot(scriptPackageRoot)
+
+  const detectedRepoRoot = await findUpward({
+    start: cwd,
+    predicate: isPlaitedSourceRoot,
+  })
+
+  const repoRoot =
+    explicitRepoRoot ?? detectedRepoRoot ?? (scriptPackageRootIsSourceRepo ? scriptPackageRoot : undefined)
+
+  const packageRoot = explicitPackageRoot ?? (isInsideNodeModules(scriptPackageRoot) ? scriptPackageRoot : undefined)
+
+  const mode: OperationalContext['mode'] =
+    overrides.mode ??
+    (repoRoot && (isSubPath(cwd, repoRoot) || scriptPackageRootIsSourceRepo)
+      ? 'repo'
+      : packageRoot
+        ? 'package'
+        : 'workspace')
+
+  let workspaceRoot: string
+  if (explicitWorkspaceRoot) {
+    workspaceRoot = explicitWorkspaceRoot
+  } else if (mode === 'repo' && repoRoot) {
+    workspaceRoot = repoRoot
+  } else if (mode === 'package' && packageRoot) {
+    workspaceRoot = stripNodeModulesPrefix(packageRoot) ?? (await findWorkspaceRoot(cwd))
+  } else {
+    workspaceRoot = await findWorkspaceRoot(cwd)
+  }
+
+  const nodeHome = resolveInputPath(cwd, overrides.nodeHome ?? process.env.PLAITED_NODE_HOME)
+  const explicitDbPath = resolveInputPath(cwd, overrides.dbPath ?? process.env.PLAITED_CONTEXT_DB)
+
+  let dbPath = explicitDbPath ?? resolve(nodeHome ?? workspaceRoot, DEFAULT_DB_RELATIVE_PATH)
+
+  if (!explicitDbPath && isInsideNodeModules(dbPath)) {
+    const safeBase = nodeHome ?? stripNodeModulesPrefix(packageRoot ?? cwd) ?? workspaceRoot
+    dbPath = resolve(safeBase, DEFAULT_DB_RELATIVE_PATH)
+  }
+
+  return OperationalContextSchema.parse({
+    mode,
+    cwd,
+    workspaceRoot,
+    repoRoot,
+    packageRoot,
+    nodeHome,
+    dbPath,
+  })
+}
+
+const ensureParentDirectory = async (dbPath: string) => {
+  if (dbPath === ':memory:' || dbPath.startsWith('file:')) {
+    return
+  }
+
+  await mkdir(dirname(dbPath), { recursive: true })
+}
+
+const getSchemaSql = async () => {
+  if (cachedSchemaSql) {
+    return cachedSchemaSql
+  }
+
+  cachedSchemaSql = await Bun.file(SCHEMA_SQL_PATH).text()
+  return cachedSchemaSql
+}
+
+export const openContextDatabase = async ({ dbPath }: { dbPath: string }): Promise<Database> => {
+  await ensureParentDirectory(dbPath)
+  const db = new Database(dbPath, { create: true })
+  db.exec('PRAGMA foreign_keys = ON;')
+  db.exec(await getSchemaSql())
+  return db
+}
+
+export const closeContextDatabase = (db: Database) => {
+  db.close(false)
+}
+
+const createLineResolver = (source: string) => {
+  const starts: number[] = [0]
+
+  for (let index = 0; index < source.length; index += 1) {
+    if (source[index] === '\n') {
+      starts.push(index + 1)
+    }
+  }
+
+  return (index: number): number => {
+    let low = 0
+    let high = starts.length - 1
+
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2)
+      const middleStart = starts[middle] ?? 0
+      const nextStart = starts[middle + 1] ?? Number.POSITIVE_INFINITY
+
+      if (middleStart <= index && index < nextStart) {
+        return middle + 1
+      }
+
+      if (index < middleStart) {
+        high = middle - 1
+      } else {
+        low = middle + 1
+      }
+    }
+
+    return starts.length
+  }
+}
+
+const classifyFileKind = (relativePath: string): 'source' | 'skill' | 'doc' | 'other' => {
+  if (relativePath.endsWith('/SKILL.md') || relativePath === 'SKILL.md') {
+    return 'skill'
+  }
+
+  if (relativePath.endsWith('.md')) {
+    return 'doc'
+  }
+
+  if (SOURCE_EXTENSIONS.has(extname(relativePath).toLowerCase())) {
+    return 'source'
+  }
+
+  return 'other'
+}
+
+const shouldIndexFile = (absolutePath: string): boolean => {
+  const ext = extname(absolutePath).toLowerCase()
+  if (basename(absolutePath) === 'SKILL.md') {
+    return true
+  }
+
+  return TEXT_EXTENSIONS.has(ext)
+}
+
+const collectFilesForIndexing = async ({
+  rootDir,
+  include,
+}: {
+  rootDir: string
+  include: string[]
+}): Promise<string[]> => {
+  const absoluteRoot = resolve(rootDir)
+  const files = new Set<string>()
+
+  for (const includePath of include) {
+    const trimmed = includePath.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const normalizedInclude = trimmed.replace(/^\.\//, '').replace(/\/$/, '')
+    const glob = new Glob(`${normalizedInclude}/**/*`)
+
+    for await (const foundPath of glob.scan({ cwd: absoluteRoot, absolute: true })) {
+      if (!shouldIndexFile(foundPath)) {
+        continue
+      }
+
+      files.add(resolve(foundPath))
+    }
+  }
+
+  return [...files].sort((left, right) => left.localeCompare(right))
+}
+
+const parseSymbols = (source: string): SymbolRow[] => {
+  const lines = source.split(/\r?\n/)
+  const seen = new Set<string>()
+  const symbols: SymbolRow[] = []
+
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1
+
+    for (const { kind, pattern } of SYMBOL_PATTERNS) {
+      const match = pattern.exec(line)
+      if (!match) {
+        continue
+      }
+
+      const name = match[1]
+      if (!name) {
+        continue
+      }
+
+      const dedupeKey = `${name}:${kind}:${lineNumber}`
+      if (seen.has(dedupeKey)) {
+        continue
+      }
+
+      seen.add(dedupeKey)
+      symbols.push({
+        name,
+        kind,
+        line: lineNumber,
+      })
+    }
+  }
+
+  return symbols
+}
+
+const parseImports = (source: string): ImportRow[] => {
+  const lineForIndex = createLineResolver(source)
+  const imports: ImportRow[] = []
+  const seen = new Set<string>()
+
+  for (const match of source.matchAll(IMPORT_PATTERN)) {
+    const specifier = match[1]
+    const index = match.index ?? 0
+    if (!specifier) {
+      continue
+    }
+
+    const line = lineForIndex(index)
+    const isType = (match[0] ?? '').includes('import type')
+    const key = `${specifier}:${line}:${isType}`
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    imports.push({
+      specifier,
+      line,
+      isType,
+    })
+  }
+
+  for (const match of source.matchAll(EXPORT_FROM_PATTERN)) {
+    const specifier = match[1]
+    const index = match.index ?? 0
+    if (!specifier) {
+      continue
+    }
+
+    const line = lineForIndex(index)
+    const isType = (match[0] ?? '').includes('export type')
+    const key = `${specifier}:${line}:${isType}`
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    imports.push({
+      specifier,
+      line,
+      isType,
+    })
+  }
+
+  return imports
+}
+
+const parseExports = (source: string): ExportRow[] => {
+  const lineForIndex = createLineResolver(source)
+  const exports: ExportRow[] = []
+  const seen = new Set<string>()
+
+  for (const match of source.matchAll(EXPORT_DECLARATION_PATTERN)) {
+    const kind = match[1]
+    const name = match[2]
+    const index = match.index ?? 0
+
+    if (!kind || !name) {
+      continue
+    }
+
+    const line = lineForIndex(index)
+    const key = `${name}:${kind}:${line}`
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    exports.push({
+      name,
+      kind,
+      line,
+    })
+  }
+
+  for (const match of source.matchAll(EXPORT_NAMED_PATTERN)) {
+    const content = match[1]
+    const index = match.index ?? 0
+    if (!content) {
+      continue
+    }
+
+    const line = lineForIndex(index)
+    const parts = content.split(',')
+
+    for (const part of parts) {
+      const normalized = part.trim().replace(/^type\s+/, '')
+      if (!normalized) {
+        continue
+      }
+
+      const aliasParts = normalized.split(/\s+as\s+/)
+      const exportedName = aliasParts[1] ?? aliasParts[0]
+      if (!exportedName) {
+        continue
+      }
+
+      const key = `${exportedName}:named:${line}`
+      if (seen.has(key)) {
+        continue
+      }
+
+      seen.add(key)
+      exports.push({
+        name: exportedName,
+        kind: 'named',
+        line,
+      })
+    }
+  }
+
+  return exports
+}
+
+const parseSkillFrontmatter = ({
+  path,
+  markdown,
+}: {
+  path: string
+  markdown: string
+}): {
+  name: string
+  description: string
+  license?: string
+  compatibility?: string
+} => {
+  try {
+    const { frontmatter } = parseMarkdownWithFrontmatter(markdown, SKILL_FRONTMATTER_SCHEMA)
+    return {
+      name: frontmatter.name,
+      description: frontmatter.description,
+      license: frontmatter.license,
+      compatibility: frontmatter.compatibility,
+    }
+  } catch {
+    return {
+      name: basename(dirname(path)),
+      description: 'Skill frontmatter failed to parse during scan.',
+    }
+  }
+}
+
+const parseDocTitle = (markdown: string): string | undefined => {
+  const heading = markdown.match(/^#\s+(.+)$/m)
+  return heading?.[1]?.trim()
+}
+
+export const indexWorkspace = async ({
+  db,
+  rootDir,
+  include,
+  force,
+}: {
+  db: Database
+  rootDir: string
+  include: string[]
+  force: boolean
+}): Promise<{
+  filesIndexed: number
+  symbolsIndexed: number
+  skillsIndexed: number
+  docsIndexed: number
+}> => {
+  if (force) {
+    db.exec('DELETE FROM symbols;')
+    db.exec('DELETE FROM imports;')
+    db.exec('DELETE FROM exports;')
+    db.exec('DELETE FROM skills;')
+    db.exec('DELETE FROM docs;')
+    db.exec('DELETE FROM files;')
+  }
+
+  const absoluteRoot = resolve(rootDir)
+  const files = await collectFilesForIndexing({ rootDir: absoluteRoot, include })
+
+  const upsertFile = db.query(
+    `INSERT INTO files (path, kind, ext, size_bytes, mtime_ms, content, indexed_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       kind = excluded.kind,
+       ext = excluded.ext,
+       size_bytes = excluded.size_bytes,
+       mtime_ms = excluded.mtime_ms,
+       content = excluded.content,
+       indexed_at = excluded.indexed_at`,
+  )
+
+  const deleteFileSymbols = db.query('DELETE FROM symbols WHERE file_path = ?')
+  const deleteFileImports = db.query('DELETE FROM imports WHERE file_path = ?')
+  const deleteFileExports = db.query('DELETE FROM exports WHERE file_path = ?')
+  const deleteFileSkill = db.query('DELETE FROM skills WHERE path = ?')
+  const deleteFileDoc = db.query('DELETE FROM docs WHERE path = ?')
+
+  const insertSymbol = db.query('INSERT INTO symbols (file_path, name, kind, line) VALUES (?, ?, ?, ?)')
+  const insertImport = db.query('INSERT INTO imports (file_path, specifier, line, is_type) VALUES (?, ?, ?, ?)')
+  const insertExport = db.query('INSERT INTO exports (file_path, name, kind, line) VALUES (?, ?, ?, ?)')
+  const upsertSkill = db.query(
+    `INSERT INTO skills (path, name, description, license, compatibility, indexed_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       name = excluded.name,
+       description = excluded.description,
+       license = excluded.license,
+       compatibility = excluded.compatibility,
+       indexed_at = excluded.indexed_at`,
+  )
+  const upsertDoc = db.query(
+    `INSERT INTO docs (path, title, body, indexed_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       title = excluded.title,
+       body = excluded.body,
+       indexed_at = excluded.indexed_at`,
+  )
+
+  let filesIndexed = 0
+  let symbolsIndexed = 0
+  let skillsIndexed = 0
+  let docsIndexed = 0
+  const indexedAt = nowIso()
+
+  for (const absolutePath of files) {
+    const file = Bun.file(absolutePath)
+    if (!(await file.exists())) {
+      continue
+    }
+
+    const content = await file.text()
+    const relativePath = toPosix(relative(absoluteRoot, absolutePath))
+    const kind = classifyFileKind(relativePath)
+    const ext = extname(relativePath).toLowerCase()
+
+    upsertFile.run(relativePath, kind, ext, file.size, file.lastModified ?? Date.now(), content, indexedAt)
+
+    deleteFileSymbols.run(relativePath)
+    deleteFileImports.run(relativePath)
+    deleteFileExports.run(relativePath)
+    deleteFileSkill.run(relativePath)
+    deleteFileDoc.run(relativePath)
+
+    const symbols = parseSymbols(content)
+    const imports = parseImports(content)
+    const exports = parseExports(content)
+
+    for (const symbol of symbols) {
+      insertSymbol.run(relativePath, symbol.name, symbol.kind, symbol.line)
+      symbolsIndexed += 1
+    }
+
+    for (const importRow of imports) {
+      insertImport.run(relativePath, importRow.specifier, importRow.line, importRow.isType ? 1 : 0)
+    }
+
+    for (const exportRow of exports) {
+      insertExport.run(relativePath, exportRow.name, exportRow.kind, exportRow.line)
+    }
+
+    if (kind === 'skill') {
+      const skillMeta = parseSkillFrontmatter({
+        path: relativePath,
+        markdown: content,
+      })
+
+      upsertSkill.run(
+        relativePath,
+        skillMeta.name,
+        skillMeta.description,
+        skillMeta.license ?? null,
+        skillMeta.compatibility ?? null,
+        indexedAt,
+      )
+      skillsIndexed += 1
+    }
+
+    if (kind === 'doc' || kind === 'skill') {
+      upsertDoc.run(relativePath, parseDocTitle(content) ?? null, content, indexedAt)
+      docsIndexed += 1
+    }
+
+    filesIndexed += 1
+  }
+
+  return {
+    filesIndexed,
+    symbolsIndexed,
+    skillsIndexed,
+    docsIndexed,
+  }
+}
+
+const escapeLike = (value: string): string =>
+  value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')
+
+const buildSnippet = ({ text, query }: { text: string; query: string }) => {
+  const normalizedText = text.toLowerCase()
+  const normalizedQuery = query.toLowerCase()
+  const position = normalizedText.indexOf(normalizedQuery)
+  if (position === -1) {
+    return text.slice(0, 220).trim()
+  }
+
+  const start = Math.max(0, position - 80)
+  const end = Math.min(text.length, position + query.length + 140)
+  return text.slice(start, end).trim()
+}
+
+export const searchContextDatabase = ({
+  db,
+  query,
+  limit,
+}: {
+  db: Database
+  query: string
+  limit: number
+}): SearchResultEntry[] => {
+  const likePattern = `%${escapeLike(query)}%`
+
+  const fileRows = db
+    .query(
+      `SELECT path, content
+       FROM files
+       WHERE path LIKE ? ESCAPE '\\' COLLATE NOCASE OR content LIKE ? ESCAPE '\\' COLLATE NOCASE
+       LIMIT ?`,
+    )
+    .all(likePattern, likePattern, limit) as Array<{
+    path: string
+    content: string
+  }>
+
+  const docRows = db
+    .query(
+      `SELECT path, body
+       FROM docs
+       WHERE path LIKE ? ESCAPE '\\' COLLATE NOCASE OR body LIKE ? ESCAPE '\\' COLLATE NOCASE
+       LIMIT ?`,
+    )
+    .all(likePattern, likePattern, limit) as Array<{
+    path: string
+    body: string
+  }>
+
+  const findingRows = db
+    .query(
+      `SELECT id, kind, status, summary, details
+       FROM findings
+       WHERE summary LIKE ? ESCAPE '\\' COLLATE NOCASE OR COALESCE(details, '') LIKE ? ESCAPE '\\' COLLATE NOCASE
+       ORDER BY id DESC
+       LIMIT ?`,
+    )
+    .all(likePattern, likePattern, limit) as Array<{
+    id: number
+    kind: FindingKind
+    status: FindingStatus
+    summary: string
+    details: string | null
+  }>
+
+  const entries: SearchResultEntry[] = [
+    ...fileRows.map((row) => ({
+      source: 'file' as const,
+      path: row.path,
+      snippet: buildSnippet({ text: row.content, query }),
+    })),
+    ...docRows.map((row) => ({
+      source: 'doc' as const,
+      path: row.path,
+      snippet: buildSnippet({ text: row.body, query }),
+    })),
+    ...findingRows.map((row) => ({
+      source: 'finding' as const,
+      findingId: row.id,
+      kind: row.kind,
+      status: row.status,
+      summary: row.summary,
+      snippet: buildSnippet({ text: `${row.summary}\n${row.details ?? ''}`, query }),
+    })),
+  ]
+
+  return entries.slice(0, limit)
+}
+
+export const searchWithRipgrep = async ({
+  rootDir,
+  query,
+  limit,
+}: {
+  rootDir: string
+  query: string
+  limit: number
+}): Promise<SearchResultEntry[]> => {
+  const rgPath = Bun.which('rg')
+  if (!rgPath) {
+    return []
+  }
+
+  const process = Bun.spawn([rgPath, '--line-number', '--no-heading', '--smart-case', query, rootDir], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, exitCode] = await Promise.all([new Response(process.stdout).text(), process.exited])
+  if (exitCode !== 0 && exitCode !== 1) {
+    return []
+  }
+
+  const results: SearchResultEntry[] = []
+
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue
+    }
+
+    const match = line.match(/^(.+?):(\d+):(.*)$/)
+    if (!match) {
+      continue
+    }
+
+    const [, path, lineNumber, snippet] = match
+    results.push({
+      source: 'rg',
+      path: toPosix(path ?? ''),
+      line: lineNumber ? Number(lineNumber) : undefined,
+      snippet: (snippet ?? '').trim(),
+    })
+
+    if (results.length >= limit) {
+      break
+    }
+  }
+
+  return results
+}
+
+const splitQueryTerms = (task: string): string[] => {
+  return task
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 3)
+}
+
+const unique = (items: string[]): string[] => [...new Set(items)]
+const safeParseJson = (value: string): unknown | null => {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+export const assembleContext = ({
+  db,
+  task,
+  mode,
+  paths,
+}: {
+  db: Database
+  task: string
+  mode: string
+  paths: string[]
+}): ContextAssemblyOutput => {
+  const terms = splitQueryTerms(task)
+  const filesToRead = new Set<string>(paths)
+
+  const fileLimit = Math.max(6, terms.length * 3)
+  const searchTerms = terms.length > 0 ? terms : [task]
+
+  for (const term of searchTerms) {
+    const likePattern = `%${escapeLike(term)}%`
+    const rows = db
+      .query(
+        `SELECT path
+         FROM files
+         WHERE path LIKE ? ESCAPE '\\' COLLATE NOCASE OR content LIKE ? ESCAPE '\\' COLLATE NOCASE
+         ORDER BY indexed_at DESC
+         LIMIT ?`,
+      )
+      .all(likePattern, likePattern, fileLimit) as Array<{ path: string }>
+
+    for (const row of rows) {
+      filesToRead.add(row.path)
+    }
+  }
+
+  const skillRows = new Set<string>()
+  for (const term of searchTerms) {
+    const likePattern = `%${escapeLike(term)}%`
+    const matches = db
+      .query(
+        `SELECT name
+         FROM skills
+         WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE OR description LIKE ? ESCAPE '\\' COLLATE NOCASE
+         ORDER BY name ASC
+         LIMIT 8`,
+      )
+      .all(likePattern, likePattern) as Array<{ name: string }>
+    for (const match of matches) {
+      skillRows.add(match.name)
+    }
+  }
+
+  const findingPatternRows = db
+    .query(
+      `SELECT summary, status
+       FROM findings
+       WHERE kind = 'pattern' AND status != 'retired'
+       ORDER BY CASE status WHEN 'validated' THEN 0 ELSE 1 END, id DESC
+       LIMIT 20`,
+    )
+    .all() as Array<{ summary: string; status: FindingStatus }>
+
+  const findingAntiPatternRows = db
+    .query(
+      `SELECT summary, status
+       FROM findings
+       WHERE kind = 'anti-pattern' AND status != 'retired'
+       ORDER BY CASE status WHEN 'validated' THEN 0 ELSE 1 END, id DESC
+       LIMIT 20`,
+    )
+    .all() as Array<{ summary: string; status: FindingStatus }>
+
+  const commandsToRun =
+    mode === 'review'
+      ? ['bun --bun tsc --noEmit', 'bun test <targeted-files-or-surface>']
+      : mode === 'docs'
+        ? ['bun skills/plaited-context/scripts/scan.ts "{"rootDir":".","include":["docs","skills"]}"']
+        : [
+            'bun --bun tsc --noEmit',
+            'bun test <targeted-files-or-surface>',
+            'bun skills/plaited-context/scripts/search.ts',
+          ]
+
+  const sourceOfTruth = unique(['AGENTS.md', ...paths, 'src/', 'skills/', 'docs/'])
+
+  const openQuestions: string[] = []
+  if (filesToRead.size === 0) {
+    openQuestions.push('No indexed files matched the task. Run scan with a broader include list or force refresh.')
+  }
+  if (skillRows.size === 0) {
+    openQuestions.push('No skill matches found for the task terms. Confirm if a new skill should be introduced.')
+  }
+
+  return {
+    ok: true,
+    filesToRead: [...filesToRead].slice(0, 20),
+    skillsToUse: unique([...skillRows]).slice(0, 10),
+    commandsToRun,
+    knownPatterns: findingPatternRows.map((row) => `${row.status}: ${row.summary}`),
+    knownAntiPatterns: findingAntiPatternRows.map((row) => `${row.status}: ${row.summary}`),
+    sourceOfTruth,
+    openQuestions,
+  }
+}
+
+export const recordFinding = ({
+  db,
+  finding,
+}: {
+  db: Database
+  finding: FindingInput
+}): {
+  findingId: number
+  evidenceCount: number
+} => {
+  if (finding.status !== 'candidate' && finding.evidence.length === 0) {
+    throw new Error('Validated or retired findings require at least one evidence item.')
+  }
+
+  const insertFinding = db.query(
+    `INSERT INTO findings (kind, status, summary, details, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+
+  const insertEvidence = db.query(
+    `INSERT INTO finding_evidence (finding_id, path, line, symbol, excerpt, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+
+  const timestamp = nowIso()
+  const transaction = db.transaction(() => {
+    const insertResult = insertFinding.run(
+      finding.kind,
+      finding.status,
+      finding.summary,
+      finding.details ?? null,
+      timestamp,
+      timestamp,
+    )
+
+    const findingId = Number(insertResult.lastInsertRowid)
+
+    for (const evidence of finding.evidence) {
+      insertEvidence.run(
+        findingId,
+        evidence.path,
+        evidence.line ?? null,
+        evidence.symbol ?? null,
+        evidence.excerpt ?? null,
+        timestamp,
+      )
+    }
+
+    if (finding.status !== 'candidate' && finding.evidence.length === 0) {
+      throw new Error('Validated or retired findings require at least one evidence item.')
+    }
+
+    return {
+      findingId,
+      evidenceCount: finding.evidence.length,
+    }
+  })
+
+  return transaction()
+}
+
+export const recordContextRun = ({
+  db,
+  task,
+  mode,
+  paths,
+  result,
+}: {
+  db: Database
+  task: string
+  mode: string
+  paths: string[]
+  result: ContextAssemblyOutput
+}) => {
+  db.query(
+    `INSERT INTO context_runs (task, mode, paths_json, result_json, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(task, mode, JSON.stringify(paths), JSON.stringify(result), nowIso())
+}
+
+export const exportReviewData = ({
+  db,
+  statuses,
+}: {
+  db: Database
+  statuses: FindingStatus[]
+}): {
+  findings: Array<{
+    id: number
+    kind: FindingKind
+    status: FindingStatus
+    summary: string
+    details: string | null
+    createdAt: string
+    updatedAt: string
+    evidence: FindingEvidenceInput[]
+  }>
+  contextRuns: Array<{
+    id: number
+    task: string
+    mode: string
+    paths: string[]
+    result: ContextAssemblyOutput | null
+    createdAt: string
+  }>
+} => {
+  const placeholders = statuses.map(() => '?').join(', ')
+
+  const findings = db
+    .query(
+      `SELECT id, kind, status, summary, details, created_at, updated_at
+       FROM findings
+       WHERE status IN (${placeholders})
+       ORDER BY id ASC`,
+    )
+    .all(...statuses) as Array<{
+    id: number
+    kind: FindingKind
+    status: FindingStatus
+    summary: string
+    details: string | null
+    created_at: string
+    updated_at: string
+  }>
+
+  const evidenceRows = db
+    .query(
+      `SELECT finding_id, path, line, symbol, excerpt
+       FROM finding_evidence
+       WHERE finding_id IN (${findings.map(() => '?').join(', ') || 'NULL'})
+       ORDER BY id ASC`,
+    )
+    .all(...findings.map((finding) => finding.id)) as Array<{
+    finding_id: number
+    path: string
+    line: number | null
+    symbol: string | null
+    excerpt: string | null
+  }>
+
+  const evidenceByFinding = new Map<number, FindingEvidenceInput[]>()
+
+  for (const evidence of evidenceRows) {
+    const collection = evidenceByFinding.get(evidence.finding_id) ?? []
+    collection.push(
+      FindingEvidenceSchema.parse({
+        path: evidence.path,
+        line: evidence.line ?? undefined,
+        symbol: evidence.symbol ?? undefined,
+        excerpt: evidence.excerpt ?? undefined,
+      }),
+    )
+    evidenceByFinding.set(evidence.finding_id, collection)
+  }
+
+  const contextRunRows = db
+    .query(
+      `SELECT id, task, mode, paths_json, result_json, created_at
+       FROM context_runs
+       ORDER BY id ASC`,
+    )
+    .all() as Array<{
+    id: number
+    task: string
+    mode: string
+    paths_json: string
+    result_json: string
+    created_at: string
+  }>
+
+  return {
+    findings: findings.map((finding) => ({
+      id: finding.id,
+      kind: finding.kind,
+      status: finding.status,
+      summary: finding.summary,
+      details: finding.details,
+      createdAt: finding.created_at,
+      updatedAt: finding.updated_at,
+      evidence: evidenceByFinding.get(finding.id) ?? [],
+    })),
+    contextRuns: contextRunRows.map((row) => {
+      const parsedPaths = z.array(z.string()).safeParse(safeParseJson(row.paths_json))
+      const parsedResult = z.unknown().safeParse(safeParseJson(row.result_json))
+
+      return {
+        id: row.id,
+        task: row.task,
+        mode: row.mode,
+        paths: parsedPaths.success ? parsedPaths.data : [],
+        result: parsedResult.success ? (parsedResult.data as ContextAssemblyOutput) : null,
+        createdAt: row.created_at,
+      }
+    }),
+  }
+}

--- a/skills/plaited-context/scripts/record-finding.ts
+++ b/skills/plaited-context/scripts/record-finding.ts
@@ -10,15 +10,17 @@ import {
 } from './plaited-context.ts'
 
 export const RecordFindingInputSchema = OperationalContextOverrideSchema.extend({
-  finding: FindingInputSchema,
-})
+  finding: FindingInputSchema.describe('Finding payload to insert into the context database.'),
+}).describe('Input contract for recording a finding with optional evidence.')
 
-export const RecordFindingOutputSchema = z.object({
-  ok: z.literal(true),
-  dbPath: z.string().min(1),
-  findingId: z.number().int().positive(),
-  evidenceCount: z.number().int().nonnegative(),
-})
+export const RecordFindingOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates finding insertion completed successfully.'),
+    dbPath: z.string().min(1).describe('Resolved writable SQLite DB path.'),
+    findingId: z.number().int().positive().describe('Inserted finding row id.'),
+    evidenceCount: z.number().int().nonnegative().describe('Number of evidence rows inserted.'),
+  })
+  .describe('Output contract for recording a finding.')
 
 export type RecordFindingInput = z.infer<typeof RecordFindingInputSchema>
 export type RecordFindingOutput = z.infer<typeof RecordFindingOutputSchema>

--- a/skills/plaited-context/scripts/record-finding.ts
+++ b/skills/plaited-context/scripts/record-finding.ts
@@ -1,0 +1,61 @@
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  closeContextDatabase,
+  FindingInputSchema,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  recordFinding,
+  resolveOperationalContext,
+} from './plaited-context.ts'
+
+export const RecordFindingInputSchema = OperationalContextOverrideSchema.extend({
+  finding: FindingInputSchema,
+})
+
+export const RecordFindingOutputSchema = z.object({
+  ok: z.literal(true),
+  dbPath: z.string().min(1),
+  findingId: z.number().int().positive(),
+  evidenceCount: z.number().int().nonnegative(),
+})
+
+export type RecordFindingInput = z.infer<typeof RecordFindingInputSchema>
+export type RecordFindingOutput = z.infer<typeof RecordFindingOutputSchema>
+
+export const recordFindingEntry = async (input: RecordFindingInput): Promise<RecordFindingOutput> => {
+  const context = await resolveOperationalContext(input)
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+
+  try {
+    const result = recordFinding({
+      db,
+      finding: input.finding,
+    })
+
+    return {
+      ok: true,
+      dbPath: context.dbPath,
+      findingId: result.findingId,
+      evidenceCount: result.evidenceCount,
+    }
+  } finally {
+    closeContextDatabase(db)
+  }
+}
+
+export const recordFindingCli = makeCli({
+  name: 'skills/plaited-context/scripts/record-finding.ts',
+  inputSchema: RecordFindingInputSchema,
+  outputSchema: RecordFindingOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/record-finding.ts '{"finding":{"kind":"anti-pattern","status":"candidate","summary":"Avoid local ZodError recovery","evidence":[{"path":"src/modules/example.ts","line":100,"symbol":"server_start"}]}}'`,
+    `  bun skills/plaited-context/scripts/record-finding.ts --schema input`,
+  ].join('\n'),
+  run: recordFindingEntry,
+})
+
+if (import.meta.main) {
+  await recordFindingCli(Bun.argv.slice(2))
+}

--- a/skills/plaited-context/scripts/scan.ts
+++ b/skills/plaited-context/scripts/scan.ts
@@ -10,19 +10,24 @@ import {
 } from './plaited-context.ts'
 
 export const ScanInputSchema = OperationalContextOverrideSchema.extend({
-  rootDir: z.string().min(1).default('.'),
-  include: z.array(z.string().min(1)).default(['src', 'skills', 'docs']),
-  force: z.boolean().default(false),
-})
+  rootDir: z.string().min(1).default('.').describe('Root directory to scan and index.'),
+  include: z
+    .array(z.string().min(1))
+    .default(['src', 'skills', 'docs'])
+    .describe('Relative include paths under rootDir to index.'),
+  force: z.boolean().default(false).describe('When true, clears prior index state before indexing.'),
+}).describe('Input contract for scanning and indexing workspace context.')
 
-export const ScanOutputSchema = z.object({
-  ok: z.literal(true),
-  dbPath: z.string().min(1),
-  filesIndexed: z.number().int().nonnegative(),
-  symbolsIndexed: z.number().int().nonnegative(),
-  skillsIndexed: z.number().int().nonnegative(),
-  docsIndexed: z.number().int().nonnegative(),
-})
+export const ScanOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates scan completed successfully.'),
+    dbPath: z.string().min(1).describe('Resolved writable SQLite DB path.'),
+    filesIndexed: z.number().int().nonnegative().describe('Count of indexed files.'),
+    symbolsIndexed: z.number().int().nonnegative().describe('Count of indexed symbols.'),
+    skillsIndexed: z.number().int().nonnegative().describe('Count of indexed skills.'),
+    docsIndexed: z.number().int().nonnegative().describe('Count of indexed docs.'),
+  })
+  .describe('Output summary for a scan/index run.')
 
 export type ScanInput = z.infer<typeof ScanInputSchema>
 export type ScanOutput = z.infer<typeof ScanOutputSchema>

--- a/skills/plaited-context/scripts/scan.ts
+++ b/skills/plaited-context/scripts/scan.ts
@@ -1,0 +1,70 @@
+import { resolve } from 'node:path'
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  closeContextDatabase,
+  indexWorkspace,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  resolveOperationalContext,
+} from './plaited-context.ts'
+
+export const ScanInputSchema = OperationalContextOverrideSchema.extend({
+  rootDir: z.string().min(1).default('.'),
+  include: z.array(z.string().min(1)).default(['src', 'skills', 'docs']),
+  force: z.boolean().default(false),
+})
+
+export const ScanOutputSchema = z.object({
+  ok: z.literal(true),
+  dbPath: z.string().min(1),
+  filesIndexed: z.number().int().nonnegative(),
+  symbolsIndexed: z.number().int().nonnegative(),
+  skillsIndexed: z.number().int().nonnegative(),
+  docsIndexed: z.number().int().nonnegative(),
+})
+
+export type ScanInput = z.infer<typeof ScanInputSchema>
+export type ScanOutput = z.infer<typeof ScanOutputSchema>
+
+export const scanWorkspace = async (input: ScanInput): Promise<ScanOutput> => {
+  const context = await resolveOperationalContext(input)
+  const rootDir = resolve(context.cwd, input.rootDir)
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+
+  try {
+    const result = await indexWorkspace({
+      db,
+      rootDir,
+      include: input.include,
+      force: input.force,
+    })
+
+    return {
+      ok: true,
+      dbPath: context.dbPath,
+      filesIndexed: result.filesIndexed,
+      symbolsIndexed: result.symbolsIndexed,
+      skillsIndexed: result.skillsIndexed,
+      docsIndexed: result.docsIndexed,
+    }
+  } finally {
+    closeContextDatabase(db)
+  }
+}
+
+export const scanCli = makeCli({
+  name: 'skills/plaited-context/scripts/scan.ts',
+  inputSchema: ScanInputSchema,
+  outputSchema: ScanOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["src","skills","docs"],"force":true}'`,
+    `  bun skills/plaited-context/scripts/scan.ts --schema output`,
+  ].join('\n'),
+  run: scanWorkspace,
+})
+
+if (import.meta.main) {
+  await scanCli(Bun.argv.slice(2))
+}

--- a/skills/plaited-context/scripts/scan.ts
+++ b/skills/plaited-context/scripts/scan.ts
@@ -13,7 +13,7 @@ export const ScanInputSchema = OperationalContextOverrideSchema.extend({
   rootDir: z.string().min(1).default('.').describe('Root directory to scan and index.'),
   include: z
     .array(z.string().min(1))
-    .default(['src', 'skills', 'docs'])
+    .default(['AGENTS.md', 'src', 'skills', 'docs'])
     .describe('Relative include paths under rootDir to index.'),
   force: z.boolean().default(false).describe('When true, clears prior index state before indexing.'),
 }).describe('Input contract for scanning and indexing workspace context.')
@@ -25,7 +25,7 @@ export const ScanOutputSchema = z
     filesIndexed: z.number().int().nonnegative().describe('Count of indexed files.'),
     symbolsIndexed: z.number().int().nonnegative().describe('Count of indexed symbols.'),
     skillsIndexed: z.number().int().nonnegative().describe('Count of indexed skills.'),
-    docsIndexed: z.number().int().nonnegative().describe('Count of indexed docs.'),
+    wikiIndexed: z.number().int().nonnegative().describe('Count of indexed wiki/reference documents.'),
   })
   .describe('Output summary for a scan/index run.')
 
@@ -51,7 +51,7 @@ export const scanWorkspace = async (input: ScanInput): Promise<ScanOutput> => {
       filesIndexed: result.filesIndexed,
       symbolsIndexed: result.symbolsIndexed,
       skillsIndexed: result.skillsIndexed,
-      docsIndexed: result.docsIndexed,
+      wikiIndexed: result.wikiIndexed,
     }
   } finally {
     closeContextDatabase(db)
@@ -64,7 +64,7 @@ export const scanCli = makeCli({
   outputSchema: ScanOutputSchema,
   help: [
     'Examples:',
-    `  bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["src","skills","docs"],"force":true}'`,
+    `  bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","src","skills","docs"],"force":true}'`,
     `  bun skills/plaited-context/scripts/scan.ts --schema output`,
   ].join('\n'),
   run: scanWorkspace,

--- a/skills/plaited-context/scripts/search.ts
+++ b/skills/plaited-context/scripts/search.ts
@@ -10,32 +10,42 @@ import {
   searchWithRipgrep,
 } from './plaited-context.ts'
 
-const SearchResultSchema = z.object({
-  source: z.enum(['file', 'doc', 'finding', 'rg']),
-  path: z.string().optional(),
-  line: z.number().int().positive().optional(),
-  symbol: z.string().optional(),
-  findingId: z.number().int().positive().optional(),
-  status: z.enum(['candidate', 'validated', 'retired']).optional(),
-  kind: z.enum(['pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question']).optional(),
-  summary: z.string().optional(),
-  snippet: z.string(),
-})
+const SearchResultSchema = z
+  .object({
+    source: z.enum(['file', 'doc', 'finding', 'rg']).describe('Search source for this result row.'),
+    path: z.string().optional().describe('Optional source file path for the hit.'),
+    line: z.number().int().positive().optional().describe('Optional 1-based line number for the hit.'),
+    symbol: z.string().optional().describe('Optional symbol associated with the hit.'),
+    findingId: z.number().int().positive().optional().describe('Optional finding id when source is a finding.'),
+    status: z
+      .enum(['candidate', 'validated', 'retired'])
+      .optional()
+      .describe('Finding lifecycle status when applicable.'),
+    kind: z
+      .enum(['pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question'])
+      .optional()
+      .describe('Finding classification when applicable.'),
+    summary: z.string().optional().describe('Optional finding summary when applicable.'),
+    snippet: z.string().describe('Text snippet representing the match.'),
+  })
+  .describe('Single search result entry.')
 
 export const SearchInputSchema = OperationalContextOverrideSchema.extend({
-  query: z.string().min(1),
-  limit: z.number().int().positive().max(500).default(20),
-  rootDir: z.string().min(1).default('.'),
-  fallbackToRipgrep: z.boolean().default(true),
-})
+  query: z.string().min(1).describe('Query string to search for in indexed context.'),
+  limit: z.number().int().positive().max(500).default(20).describe('Maximum number of results to return.'),
+  rootDir: z.string().min(1).default('.').describe('Workspace root for optional ripgrep fallback scanning.'),
+  fallbackToRipgrep: z.boolean().default(true).describe('When true, runs ripgrep if indexed search has no hits.'),
+}).describe('Input contract for indexed search with optional ripgrep fallback.')
 
-export const SearchOutputSchema = z.object({
-  ok: z.literal(true),
-  dbPath: z.string().min(1),
-  query: z.string().min(1),
-  results: z.array(SearchResultSchema),
-  fallbackUsed: z.boolean(),
-})
+export const SearchOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates search completed successfully.'),
+    dbPath: z.string().min(1).describe('Resolved writable SQLite DB path.'),
+    query: z.string().min(1).describe('Echo of the executed query.'),
+    results: z.array(SearchResultSchema).describe('Ordered list of search results.'),
+    fallbackUsed: z.boolean().describe('True when ripgrep fallback produced returned results.'),
+  })
+  .describe('Output contract for context search.')
 
 export type SearchInput = z.infer<typeof SearchInputSchema>
 export type SearchOutput = z.infer<typeof SearchOutputSchema>

--- a/skills/plaited-context/scripts/search.ts
+++ b/skills/plaited-context/scripts/search.ts
@@ -12,7 +12,7 @@ import {
 
 const SearchResultSchema = z
   .object({
-    source: z.enum(['file', 'doc', 'finding', 'rg']).describe('Search source for this result row.'),
+    source: z.enum(['file', 'wiki', 'finding', 'rg']).describe('Search source for this result row.'),
     path: z.string().optional().describe('Optional source file path for the hit.'),
     line: z.number().int().positive().optional().describe('Optional 1-based line number for the hit.'),
     symbol: z.string().optional().describe('Optional symbol associated with the hit.'),

--- a/skills/plaited-context/scripts/search.ts
+++ b/skills/plaited-context/scripts/search.ts
@@ -1,0 +1,96 @@
+import { resolve } from 'node:path'
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  closeContextDatabase,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  resolveOperationalContext,
+  searchContextDatabase,
+  searchWithRipgrep,
+} from './plaited-context.ts'
+
+const SearchResultSchema = z.object({
+  source: z.enum(['file', 'doc', 'finding', 'rg']),
+  path: z.string().optional(),
+  line: z.number().int().positive().optional(),
+  symbol: z.string().optional(),
+  findingId: z.number().int().positive().optional(),
+  status: z.enum(['candidate', 'validated', 'retired']).optional(),
+  kind: z.enum(['pattern', 'anti-pattern', 'stale-doc', 'boundary-rule', 'question']).optional(),
+  summary: z.string().optional(),
+  snippet: z.string(),
+})
+
+export const SearchInputSchema = OperationalContextOverrideSchema.extend({
+  query: z.string().min(1),
+  limit: z.number().int().positive().max(500).default(20),
+  rootDir: z.string().min(1).default('.'),
+  fallbackToRipgrep: z.boolean().default(true),
+})
+
+export const SearchOutputSchema = z.object({
+  ok: z.literal(true),
+  dbPath: z.string().min(1),
+  query: z.string().min(1),
+  results: z.array(SearchResultSchema),
+  fallbackUsed: z.boolean(),
+})
+
+export type SearchInput = z.infer<typeof SearchInputSchema>
+export type SearchOutput = z.infer<typeof SearchOutputSchema>
+
+export const searchWorkspace = async (input: SearchInput): Promise<SearchOutput> => {
+  const context = await resolveOperationalContext(input)
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+
+  try {
+    const indexedResults = searchContextDatabase({
+      db,
+      query: input.query,
+      limit: input.limit,
+    })
+
+    if (indexedResults.length > 0 || !input.fallbackToRipgrep) {
+      return {
+        ok: true,
+        dbPath: context.dbPath,
+        query: input.query,
+        results: indexedResults,
+        fallbackUsed: false,
+      }
+    }
+
+    const fallbackResults = await searchWithRipgrep({
+      rootDir: resolve(context.cwd, input.rootDir),
+      query: input.query,
+      limit: input.limit,
+    })
+
+    return {
+      ok: true,
+      dbPath: context.dbPath,
+      query: input.query,
+      results: fallbackResults,
+      fallbackUsed: fallbackResults.length > 0,
+    }
+  } finally {
+    closeContextDatabase(db)
+  }
+}
+
+export const searchCli = makeCli({
+  name: 'skills/plaited-context/scripts/search.ts',
+  inputSchema: SearchInputSchema,
+  outputSchema: SearchOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/search.ts '{"query":"useSnapshot reportSnapshot","limit":20}'`,
+    `  bun skills/plaited-context/scripts/search.ts --schema input`,
+  ].join('\n'),
+  run: searchWorkspace,
+})
+
+if (import.meta.main) {
+  await searchCli(Bun.argv.slice(2))
+}

--- a/skills/plaited-context/scripts/tests/plaited-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/plaited-context.spec.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { assembleTaskContext } from '../context.ts'
+import { exportReview } from '../export-review.ts'
+import { initDb } from '../init-db.ts'
+import { resolveOperationalContext } from '../plaited-context.ts'
+import { recordFindingEntry } from '../record-finding.ts'
+import { scanWorkspace } from '../scan.ts'
+import { searchWorkspace } from '../search.ts'
+
+const tempDirs: string[] = []
+
+const createTempWorkspace = async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), 'plaited-context-'))
+  tempDirs.push(rootDir)
+
+  await Bun.write(
+    join(rootDir, 'src/example.ts'),
+    `export const useBehavioralContext = () => 'behavioral context'
+export const reportSnapshot = () => 'snapshot'
+`,
+  )
+
+  await Bun.write(
+    join(rootDir, 'skills/example-skill/SKILL.md'),
+    `---
+name: example-skill
+description: Example skill for behavioral review.
+license: ISC
+compatibility: Requires bun
+---
+
+# Example Skill
+`,
+  )
+
+  await Bun.write(
+    join(rootDir, 'docs/example.md'),
+    `# Example Doc
+
+Use the behavioral context helper during review.
+`,
+  )
+
+  return rootDir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('plaited-context scripts', () => {
+  test('resolveOperationalContext honors explicit dbPath override', async () => {
+    const context = await resolveOperationalContext({
+      cwd: process.cwd(),
+      dbPath: '/tmp/plaited-context-override.sqlite',
+    })
+
+    expect(context.dbPath).toBe('/tmp/plaited-context-override.sqlite')
+    expect(context.workspaceRoot.length).toBeGreaterThan(0)
+  })
+
+  test('indexes workspace and exports recorded findings', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    const initOutput = await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    expect(initOutput.ok).toBe(true)
+    expect(initOutput.dbPath).toBe(dbPath)
+
+    const scanOutput = await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['src', 'skills', 'docs'],
+      force: true,
+    })
+
+    expect(scanOutput.ok).toBe(true)
+    expect(scanOutput.filesIndexed).toBeGreaterThan(0)
+    expect(scanOutput.symbolsIndexed).toBeGreaterThan(0)
+    expect(scanOutput.skillsIndexed).toBeGreaterThan(0)
+    expect(scanOutput.docsIndexed).toBeGreaterThan(0)
+
+    const searchOutput = await searchWorkspace({
+      cwd: rootDir,
+      dbPath,
+      query: 'behavioral',
+      limit: 5,
+      rootDir,
+      fallbackToRipgrep: false,
+    })
+
+    expect(searchOutput.ok).toBe(true)
+    expect(searchOutput.results.length).toBeGreaterThan(0)
+
+    const contextOutput = await assembleTaskContext({
+      cwd: rootDir,
+      dbPath,
+      task: 'review behavioral module',
+      mode: 'review',
+      paths: ['src/example.ts'],
+    })
+
+    expect(contextOutput.ok).toBe(true)
+    expect(contextOutput.filesToRead).toContain('src/example.ts')
+
+    const findingOutput = await recordFindingEntry({
+      cwd: rootDir,
+      dbPath,
+      finding: {
+        kind: 'pattern',
+        status: 'candidate',
+        summary: 'Use reportSnapshot for diagnostics.',
+        evidence: [{ path: 'src/example.ts', line: 2, symbol: 'reportSnapshot' }],
+      },
+    })
+
+    expect(findingOutput.ok).toBe(true)
+    expect(findingOutput.evidenceCount).toBe(1)
+
+    await expect(
+      recordFindingEntry({
+        cwd: rootDir,
+        dbPath,
+        finding: {
+          kind: 'pattern',
+          status: 'validated',
+          summary: 'Validated findings need evidence.',
+          evidence: [],
+        },
+      }),
+    ).rejects.toThrow('Validated or retired findings require at least one evidence item.')
+
+    const exportOutput = await exportReview({
+      cwd: rootDir,
+      dbPath,
+      status: ['candidate'],
+      format: 'json',
+    })
+
+    expect(exportOutput.ok).toBe(true)
+    expect(exportOutput.findings.length).toBe(1)
+    expect(exportOutput.findings[0]?.summary).toContain('reportSnapshot')
+    expect(exportOutput.contextRuns.length).toBeGreaterThan(0)
+  })
+})

--- a/skills/plaited-context/scripts/tests/plaited-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/plaited-context.spec.ts
@@ -6,7 +6,7 @@ import { dirname, join, relative } from 'node:path'
 import { assembleTaskContext } from '../context.ts'
 import { exportReview } from '../export-review.ts'
 import { initDb } from '../init-db.ts'
-import { resolveOperationalContext } from '../plaited-context.ts'
+import { closeContextDatabase, openContextDatabase, resolveOperationalContext } from '../plaited-context.ts'
 import { recordFindingEntry } from '../record-finding.ts'
 import { scanWorkspace } from '../scan.ts'
 import { searchWorkspace } from '../search.ts'
@@ -26,6 +26,28 @@ const createTempWorkspace = async () => {
     path: join(rootDir, 'src/example.ts'),
     content: `export const useBehavioralContext = () => 'behavioral context'
 export const reportSnapshot = () => 'snapshot'
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'AGENTS.md'),
+    content: `# Agent Instructions
+
+Root operational guidance.
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'src/modules/AGENTS.md'),
+    content: `# Module Agent Instructions
+
+Scoped instructions for src/modules.
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'src/modules/example.ts'),
+    content: `export const moduleExample = () => 'module example'
 `,
   })
 
@@ -138,7 +160,7 @@ describe('plaited-context scripts', () => {
       cwd: rootDir,
       rootDir,
       dbPath,
-      include: ['src', 'skills', 'docs'],
+      include: ['AGENTS.md', 'src', 'skills', 'docs'],
       force: true,
     })
 
@@ -146,19 +168,20 @@ describe('plaited-context scripts', () => {
     expect(scanOutput.filesIndexed).toBeGreaterThan(0)
     expect(scanOutput.symbolsIndexed).toBeGreaterThan(0)
     expect(scanOutput.skillsIndexed).toBeGreaterThan(0)
-    expect(scanOutput.docsIndexed).toBeGreaterThan(0)
+    expect(scanOutput.wikiIndexed).toBeGreaterThan(0)
 
     const searchOutput = await searchWorkspace({
       cwd: rootDir,
       dbPath,
-      query: 'behavioral',
-      limit: 5,
+      query: 'Example Doc',
+      limit: 20,
       rootDir,
       fallbackToRipgrep: false,
     })
 
     expect(searchOutput.ok).toBe(true)
     expect(searchOutput.results.length).toBeGreaterThan(0)
+    expect(searchOutput.results.some((row) => row.source === 'wiki')).toBe(true)
 
     const contextOutput = await assembleTaskContext({
       cwd: rootDir,
@@ -292,5 +315,105 @@ describe('plaited-context scripts', () => {
     expect(scanOutput.ok).toBe(true)
     expect(scanOutput.filesIndexed).toBeGreaterThan(0)
     expect(scanOutput.symbolsIndexed).toBeGreaterThan(0)
+  })
+
+  test('scan supports explicit root AGENTS.md include and indexes root instruction scope', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    const scanOutput = await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['AGENTS.md'],
+      force: true,
+    })
+
+    expect(scanOutput.ok).toBe(true)
+    expect(scanOutput.filesIndexed).toBeGreaterThan(0)
+
+    const db = await openContextDatabase({ dbPath })
+    try {
+      const rootAgentsKind = db.query(`SELECT kind FROM files WHERE path = 'AGENTS.md'`).get() as {
+        kind: string
+      } | null
+      const rootAgentScope = db.query(`SELECT scope_path FROM agent_instructions WHERE path = 'AGENTS.md'`).get() as {
+        scope_path: string
+      } | null
+
+      expect(rootAgentsKind?.kind).toBe('agent-instructions')
+      expect(rootAgentScope?.scope_path).toBe('.')
+    } finally {
+      closeContextDatabase(db)
+    }
+  })
+
+  test('scan supports explicit nested AGENTS.md file includes and indexes nested instruction scope', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    const scanOutput = await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['src/modules/AGENTS.md'],
+      force: true,
+    })
+
+    expect(scanOutput.ok).toBe(true)
+    expect(scanOutput.filesIndexed).toBeGreaterThan(0)
+
+    const db = await openContextDatabase({ dbPath })
+    try {
+      const nestedAgentScope = db
+        .query(`SELECT scope_path FROM agent_instructions WHERE path = 'src/modules/AGENTS.md'`)
+        .get() as { scope_path: string } | null
+
+      expect(nestedAgentScope?.scope_path).toBe('src/modules')
+    } finally {
+      closeContextDatabase(db)
+    }
+  })
+
+  test('scan supports explicit directory includes and indexes AGENTS.md found under that directory', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    const scanOutput = await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['src'],
+      force: true,
+    })
+
+    expect(scanOutput.ok).toBe(true)
+    expect(scanOutput.filesIndexed).toBeGreaterThan(0)
+
+    const db = await openContextDatabase({ dbPath })
+    try {
+      const nestedAgentScope = db
+        .query(`SELECT scope_path FROM agent_instructions WHERE path = 'src/modules/AGENTS.md'`)
+        .get() as { scope_path: string } | null
+
+      expect(nestedAgentScope?.scope_path).toBe('src/modules')
+    } finally {
+      closeContextDatabase(db)
+    }
   })
 })

--- a/skills/plaited-context/scripts/tests/plaited-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/plaited-context.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 
 import { assembleTaskContext } from '../context.ts'
 import { exportReview } from '../export-review.ts'
@@ -13,20 +13,25 @@ import { searchWorkspace } from '../search.ts'
 
 const tempDirs: string[] = []
 
+const writeTempFile = async ({ path, content }: { path: string; content: string }) => {
+  await mkdir(dirname(path), { recursive: true })
+  await Bun.write(path, content)
+}
+
 const createTempWorkspace = async () => {
   const rootDir = await mkdtemp(join(tmpdir(), 'plaited-context-'))
   tempDirs.push(rootDir)
 
-  await Bun.write(
-    join(rootDir, 'src/example.ts'),
-    `export const useBehavioralContext = () => 'behavioral context'
+  await writeTempFile({
+    path: join(rootDir, 'src/example.ts'),
+    content: `export const useBehavioralContext = () => 'behavioral context'
 export const reportSnapshot = () => 'snapshot'
 `,
-  )
+  })
 
-  await Bun.write(
-    join(rootDir, 'skills/example-skill/SKILL.md'),
-    `---
+  await writeTempFile({
+    path: join(rootDir, 'skills/example-skill/SKILL.md'),
+    content: `---
 name: example-skill
 description: Example skill for behavioral review.
 license: ISC
@@ -35,15 +40,15 @@ compatibility: Requires bun
 
 # Example Skill
 `,
-  )
+  })
 
-  await Bun.write(
-    join(rootDir, 'docs/example.md'),
-    `# Example Doc
+  await writeTempFile({
+    path: join(rootDir, 'docs/example.md'),
+    content: `# Example Doc
 
 Use the behavioral context helper during review.
 `,
-  )
+  })
 
   return rootDir
 }
@@ -61,6 +66,60 @@ describe('plaited-context scripts', () => {
 
     expect(context.dbPath).toBe('/tmp/plaited-context-override.sqlite')
     expect(context.workspaceRoot.length).toBeGreaterThan(0)
+  })
+
+  test('resolveOperationalContext supports explicit packageRoot without forcing repo mode', async () => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), 'plaited-context-workspace-'))
+    tempDirs.push(workspaceDir)
+
+    const packageRoot = join(workspaceDir, 'node_modules/plaited')
+    await mkdir(packageRoot, { recursive: true })
+
+    const context = await resolveOperationalContext({
+      cwd: workspaceDir,
+      packageRoot,
+    })
+
+    expect(context.mode).toBe('package')
+    expect(context.packageRoot).toBe(packageRoot)
+    expect(context.dbPath.startsWith(join(workspaceDir, '.plaited'))).toBe(true)
+    expect(context.dbPath.includes('/node_modules/')).toBe(false)
+  })
+
+  test('resolveOperationalContext does not force repo mode from script location outside repo cwd', async () => {
+    const externalCwd = await mkdtemp(join(tmpdir(), 'plaited-context-external-'))
+    tempDirs.push(externalCwd)
+
+    const workspaceContext = await resolveOperationalContext({
+      cwd: externalCwd,
+    })
+    expect(workspaceContext.mode).toBe('workspace')
+    expect(workspaceContext.repoRoot).toBeUndefined()
+    expect(workspaceContext.dbPath.startsWith(join(externalCwd, '.plaited'))).toBe(true)
+
+    const explicitModeContext = await resolveOperationalContext({
+      cwd: externalCwd,
+      mode: 'repo',
+    })
+    expect(explicitModeContext.mode).toBe('repo')
+
+    const explicitRepoContext = await resolveOperationalContext({
+      cwd: externalCwd,
+      repoRoot: process.cwd(),
+    })
+    expect(explicitRepoContext.mode).toBe('repo')
+    expect(explicitRepoContext.repoRoot).toBeDefined()
+    expect(explicitRepoContext.repoRoot ?? '').toBe(process.cwd())
+  })
+
+  test('resolveOperationalContext keeps repo mode behavior when cwd is inside repo', async () => {
+    const context = await resolveOperationalContext({
+      cwd: process.cwd(),
+    })
+
+    expect(context.mode).toBe('repo')
+    expect(context.repoRoot).toBeDefined()
+    expect(context.workspaceRoot).toBe(context.repoRoot ?? '')
   })
 
   test('indexes workspace and exports recorded findings', async () => {
@@ -150,5 +209,88 @@ describe('plaited-context scripts', () => {
     expect(exportOutput.findings.length).toBe(1)
     expect(exportOutput.findings[0]?.summary).toContain('reportSnapshot')
     expect(exportOutput.contextRuns.length).toBeGreaterThan(0)
+  })
+
+  test('scan rejects include paths that escape rootDir and does not index outside files', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+    const outsideDir = await mkdtemp(join(tmpdir(), 'plaited-context-outside-'))
+    tempDirs.push(outsideDir)
+    const outsideFilePath = join(outsideDir, 'outside-context-escape.ts')
+    const escapeInclude = relative(rootDir, outsideFilePath)
+    const outsideMarker = 'OUTSIDE_CONTEXT_ESCAPE_MARKER'
+
+    await writeTempFile({
+      path: outsideFilePath,
+      content: `export const outsideMarker = '${outsideMarker}'`,
+    })
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    await expect(
+      scanWorkspace({
+        cwd: rootDir,
+        rootDir,
+        dbPath,
+        include: [escapeInclude],
+        force: true,
+      }),
+    ).rejects.toThrow(`Invalid include path '${escapeInclude}': path escapes rootDir.`)
+
+    const searchOutput = await searchWorkspace({
+      cwd: rootDir,
+      dbPath,
+      query: outsideMarker,
+      limit: 5,
+      rootDir,
+      fallbackToRipgrep: false,
+    })
+
+    expect(searchOutput.results).toHaveLength(0)
+  })
+
+  test('scan rejects absolute include paths', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    await expect(
+      scanWorkspace({
+        cwd: rootDir,
+        rootDir,
+        dbPath,
+        include: [join(rootDir, 'src')],
+        force: true,
+      }),
+    ).rejects.toThrow('absolute paths are not allowed')
+  })
+
+  test('scan still indexes valid relative include paths', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    const scanOutput = await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['./src'],
+      force: true,
+    })
+
+    expect(scanOutput.ok).toBe(true)
+    expect(scanOutput.filesIndexed).toBeGreaterThan(0)
+    expect(scanOutput.symbolsIndexed).toBeGreaterThan(0)
   })
 })

--- a/src/cli/skills/skills.ts
+++ b/src/cli/skills/skills.ts
@@ -2,7 +2,7 @@ import { basename, dirname, join, normalize, relative, resolve } from 'node:path
 import { Glob } from 'bun'
 import * as z from 'zod'
 import { makeCli } from '../utils/cli.ts'
-import { extractLocalLinksFromMarkdown, parseMarkdownWithFrontmatter } from '../utils/markdown.ts'
+import { parseMarkdownWithFrontmatter, validateMarkdownLocalLinks } from '../utils/markdown.ts'
 import {
   type SkillCatalogEntry,
   SkillCatalogEntrySchema,
@@ -16,7 +16,6 @@ import {
   type SkillInstructionErrors,
   type SkillInstructionResourceLinksLoadResult,
   type SkillInstructionsLoadResult,
-  type SkillResourceLink,
   type SkillResourceLinks,
   type SkillResourceLinksJson,
   type SkillsCatalogCliInput,
@@ -65,12 +64,6 @@ const formatSkillValidationError = (error: unknown): string => {
 const getExpectedSkillDirectoryName = (skillPath: string): string => {
   const normalizedPath = normalize(skillPath)
   return /SKILL\.md$/i.test(normalizedPath) ? basename(dirname(normalizedPath)) : basename(normalizedPath)
-}
-
-const sortSkillResourceLinks = (left: SkillResourceLink, right: SkillResourceLink): number => {
-  const valueComparison = left.value.localeCompare(right.value)
-  if (valueComparison !== 0) return valueComparison
-  return left.text.localeCompare(right.text)
 }
 
 const toSkillResourceLinksJson = (links: SkillResourceLinks): SkillResourceLinksJson => ({
@@ -155,49 +148,6 @@ export const validateSkill = (
   return {
     ok: true,
     errors: [],
-  }
-}
-
-/**
- * Validates local markdown links referenced from a skill body.
- *
- * @param options - Skill directory and markdown body to validate.
- * @returns Lists of links that resolve and links that are missing.
- *
- * @public
- */
-export const validateSkillLocalLinks = async ({
-  skillDir,
-  markdownBody,
-}: {
-  skillDir: string
-  markdownBody: string
-}): Promise<SkillResourceLinks> => {
-  const present = new Map<string, SkillResourceLink>()
-  const missing = new Map<string, SkillResourceLink>()
-  const links = await extractLocalLinksFromMarkdown(markdownBody)
-
-  for (const link of links) {
-    const absolutePath = resolve(skillDir, link.value)
-    const file = Bun.file(absolutePath)
-    const key = `${link.value}\u0000${link.text}`
-    if (await file.exists()) {
-      present.set(key, {
-        value: link.value,
-        text: link.text || link.value,
-      })
-      continue
-    }
-
-    missing.set(key, {
-      value: link.value,
-      text: link.text || link.value,
-    })
-  }
-
-  return {
-    present: new Set([...present.values()].sort(sortSkillResourceLinks)),
-    missing: new Set([...missing.values()].sort(sortSkillResourceLinks)),
   }
 }
 
@@ -318,8 +268,8 @@ export const getSkillInstructionResourceLinks = async (
       errors,
     }
   }
-  const links = await validateSkillLocalLinks({
-    skillDir,
+  const links = await validateMarkdownLocalLinks({
+    baseDir: skillDir,
     markdownBody: body,
   })
   return { links, errors }

--- a/src/cli/skills/tests/skills.spec.ts
+++ b/src/cli/skills/tests/skills.spec.ts
@@ -12,7 +12,6 @@ import {
   skillsLinks,
   skillsValidate,
   validateSkill,
-  validateSkillLocalLinks,
 } from '../skills.ts'
 
 const CLI_PACKAGE_ROOT = resolve(import.meta.dir, '../../../../')
@@ -85,39 +84,6 @@ describe('validateSkill', () => {
       ok: false,
       errors: ['Invalid skill frontmatter: Missing YAML frontmatter'],
     })
-  })
-})
-
-describe('validateSkillLocalLinks', () => {
-  test('returns present and missing sets with link value and text', async () => {
-    const uniqueId = `${Date.now()}-${Math.random().toString(16).slice(2)}`
-    const skillDir = join('/tmp', `plaited-skill-links-${uniqueId}`)
-
-    await Bun.$`mkdir -p ${join(skillDir, 'references')} ${join(skillDir, 'scripts')}`
-    await Bun.write(join(skillDir, 'references', 'setup.md'), '# setup')
-    await Bun.write(join(skillDir, 'scripts', 'run.ts'), 'export {}\n')
-
-    const links = await validateSkillLocalLinks({
-      skillDir,
-      markdownBody: `
-See [setup guide](references/setup.md) and [missing doc](references/missing.md).
-![diagram](assets/diagram.png)
-[](<scripts/run.ts>)
-`,
-    })
-
-    expect(links.present).toBeInstanceOf(Set)
-    expect(links.missing).toBeInstanceOf(Set)
-    expect([...links.present]).toEqual([
-      { value: 'references/setup.md', text: 'setup guide' },
-      { value: 'scripts/run.ts', text: 'scripts/run.ts' },
-    ])
-    expect([...links.missing]).toEqual([
-      { value: 'assets/diagram.png', text: 'diagram' },
-      { value: 'references/missing.md', text: 'missing doc' },
-    ])
-
-    await Bun.$`rm -rf ${skillDir}`
   })
 })
 

--- a/src/cli/utils/markdown.ts
+++ b/src/cli/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { normalize } from 'node:path'
+import { normalize, resolve } from 'node:path'
 import { YAML } from 'bun'
 import * as z from 'zod'
 
@@ -158,6 +158,22 @@ export const normalizeMarkdownLink = (value: string): string | null => {
 export type LocalMarkdownLink = {
   value: string
   text: string
+}
+
+/**
+ * Set-based local markdown link validation result.
+ *
+ * @public
+ */
+export type MarkdownLocalLinksValidationResult = {
+  present: Set<LocalMarkdownLink>
+  missing: Set<LocalMarkdownLink>
+}
+
+const sortLocalMarkdownLinks = (left: LocalMarkdownLink, right: LocalMarkdownLink): number => {
+  const valueComparison = left.value.localeCompare(right.value)
+  if (valueComparison !== 0) return valueComparison
+  return left.text.localeCompare(right.text)
 }
 
 const MarkdownLinksFromPathInputSchema = z
@@ -429,4 +445,47 @@ const readMarkdownLinksSource = async (input: MarkdownLinksInput): Promise<strin
 export const markdownLinks = async (input: MarkdownLinksInput): Promise<MarkdownLinksOutput> => {
   const markdown = await readMarkdownLinksSource(input)
   return extractLocalLinksFromMarkdown(markdown)
+}
+
+/**
+ * Validates local markdown links by resolving each link target relative to a base directory.
+ *
+ * @param options - Base directory and markdown body to validate.
+ * @returns Present and missing local link sets with deterministic ordering.
+ *
+ * @public
+ */
+export const validateMarkdownLocalLinks = async ({
+  baseDir,
+  markdownBody,
+}: {
+  baseDir: string
+  markdownBody: string
+}): Promise<MarkdownLocalLinksValidationResult> => {
+  const present = new Map<string, LocalMarkdownLink>()
+  const missing = new Map<string, LocalMarkdownLink>()
+  const links = await extractLocalLinksFromMarkdown(markdownBody)
+
+  for (const link of links) {
+    const absolutePath = resolve(baseDir, link.value)
+    const file = Bun.file(absolutePath)
+    const key = `${link.value}\u0000${link.text}`
+    if (await file.exists()) {
+      present.set(key, {
+        value: link.value,
+        text: link.text || link.value,
+      })
+      continue
+    }
+
+    missing.set(key, {
+      value: link.value,
+      text: link.text || link.value,
+    })
+  }
+
+  return {
+    present: new Set([...present.values()].sort(sortLocalMarkdownLinks)),
+    missing: new Set([...missing.values()].sort(sortLocalMarkdownLinks)),
+  }
 }

--- a/src/cli/utils/tests/markdown.spec.ts
+++ b/src/cli/utils/tests/markdown.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { Blob } from 'node:buffer'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as z from 'zod'
 import {
@@ -8,6 +10,7 @@ import {
   markdownLinks,
   normalizeMarkdownLink,
   parseMarkdownWithFrontmatter,
+  validateMarkdownLocalLinks,
 } from '../markdown.ts'
 
 const TestFrontmatterSchema = z.object({
@@ -215,6 +218,41 @@ describe('markdownLinks', () => {
   test('throws when the source file does not exist', async () => {
     const missingPath = join('/tmp', `plaited-markdown-links-missing-${Date.now()}.md`)
     await expect(markdownLinks({ path: missingPath })).rejects.toThrow(`Markdown file not found: ${missingPath}`)
+  })
+})
+
+describe('validateMarkdownLocalLinks', () => {
+  test('returns present and missing sets with link value and text', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'plaited-markdown-links-'))
+
+    try {
+      await mkdir(join(baseDir, 'references'), { recursive: true })
+      await mkdir(join(baseDir, 'scripts'), { recursive: true })
+      await Bun.write(join(baseDir, 'references', 'setup.md'), '# setup')
+      await Bun.write(join(baseDir, 'scripts', 'run.ts'), 'export {}\n')
+
+      const links = await validateMarkdownLocalLinks({
+        baseDir,
+        markdownBody: `
+See [setup guide](references/setup.md) and [missing doc](references/missing.md).
+![diagram](assets/diagram.png)
+[](<scripts/run.ts>)
+`,
+      })
+
+      expect(links.present).toBeInstanceOf(Set)
+      expect(links.missing).toBeInstanceOf(Set)
+      expect([...links.present]).toEqual([
+        { value: 'references/setup.md', text: 'setup guide' },
+        { value: 'scripts/run.ts', text: 'scripts/run.ts' },
+      ])
+      expect([...links.missing]).toEqual([
+        { value: 'assets/diagram.png', text: 'diagram' },
+        { value: 'references/missing.md', text: 'missing doc' },
+      ])
+    } finally {
+      await rm(baseDir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Context

- Slice 0 for Context initiative: create `plaited-context` as a script-first,
  SQLite-backed codebase context substrate.
- Adds the new skill, assets, and runnable scripts without touching runtime
  `src/` module behavior.
- Fixes #314.

## Summary

- Added `skills/plaited-context` with required frontmatter and workflow docs.
- Added `.agents/skills/plaited-context` symlink to the new skill.
- Added SQLite schema (`bun:sqlite`) for:
  - `files`, `symbols`, `imports`, `exports`, `skills`, `docs`
  - `findings`, `finding_evidence`, `context_runs`
- Implemented operational-context resolution (`repo | package | workspace`) with
  DB path precedence:
  1. JSON `dbPath`
  2. `PLAITED_CONTEXT_DB`
  3. default `.plaited/context.sqlite`
- Implemented six JSON CLI scripts with `--schema input|output` support:
  - `init-db.ts`
  - `scan.ts`
  - `search.ts`
  - `context.ts`
  - `record-finding.ts`
  - `export-review.ts`
- Added focused tests for resolver behavior and end-to-end script workflow.

## Changed Files

- `.agents/skills/plaited-context`
- `skills/plaited-context/SKILL.md`
- `skills/plaited-context/assets/schema.sql`
- `skills/plaited-context/assets/queries/README.md`
- `skills/plaited-context/scripts/plaited-context.ts`
- `skills/plaited-context/scripts/init-db.ts`
- `skills/plaited-context/scripts/scan.ts`
- `skills/plaited-context/scripts/search.ts`
- `skills/plaited-context/scripts/context.ts`
- `skills/plaited-context/scripts/record-finding.ts`
- `skills/plaited-context/scripts/export-review.ts`
- `skills/plaited-context/scripts/tests/plaited-context.spec.ts`

## Validation

- Targeted tests:
  - `bun test skills/plaited-context/scripts/tests`
  - `bun skills/plaited-context/scripts/init-db.ts '{"dbPath":"/tmp/plaited-context-slice0-v2.sqlite"}'`
  - `bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","dbPath":"/tmp/plaited-context-slice0-v2.sqlite","include":["src/behavioral","skills"],"force":true}'`
  - `bun skills/plaited-context/scripts/search.ts '{"dbPath":"/tmp/plaited-context-slice0-v2.sqlite","query":"behavioral","limit":5}'`
  - `bun skills/plaited-context/scripts/context.ts '{"dbPath":"/tmp/plaited-context-slice0-v2.sqlite","task":"review behavioral module","mode":"review","paths":["src/behavioral/behavioral.ts"]}'`
  - `bun skills/plaited-context/scripts/record-finding.ts '{"dbPath":"/tmp/plaited-context-slice0-v2.sqlite","finding":{"kind":"pattern","status":"candidate","summary":"Test finding","evidence":[{"path":"src/behavioral/behavioral.ts","line":1}]}}'`
  - `bun skills/plaited-context/scripts/export-review.ts '{"dbPath":"/tmp/plaited-context-slice0-v2.sqlite","status":["candidate"],"format":"json"}'`
  - `bun bin/plaited.ts skills-validate '{"skillPath":"skills/plaited-context/SKILL.md"}'`
  - `bun bin/plaited.ts skills-links '{"rootDir":".","path":"skills/plaited-context"}'`
  - `bun bin/plaited.ts skills-catalog '{"rootDir":"."}'`
- `bun --bun tsc --noEmit`: pass

## Known Failures / Drift

- None observed in this slice.

## Review Notes / Residual Risks

- Scanner symbol/import/export extraction is regex-based in Slice 0 and will
  miss some complex multi-line or alias-heavy patterns; this is a known tradeoff
  for a modest initial substrate.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
