### PR TITLE
feat(skills): add wiki context assembly to plaited-context

### DIFF
--- a/skills/plaited-context/SKILL.md
+++ b/skills/plaited-context/SKILL.md
@@ -20,6 +20,7 @@ Use it before:
 - implementing a feature or fix
 - reviewing a slice or PR
 - updating wiki/reference docs and checking for stale guidance
+- large code, docs, or skill edits that need source-grounded context first
 
 ## Operational Context
 
@@ -78,19 +79,25 @@ bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md
 bun skills/plaited-context/scripts/context.ts '{"task":"review module actor diagnostics","mode":"review","paths":["src/modules/example.ts"]}'
 ```
 
-4. Run targeted search
+4. Assemble wiki context (relevance + cleanup candidates)
+
+```bash
+bun skills/plaited-context/scripts/wiki-context.ts '{"task":"review runtime module architecture","paths":["src/modules"],"limit":10}'
+```
+
+5. Run targeted search
 
 ```bash
 bun skills/plaited-context/scripts/search.ts '{"query":"useSnapshot reportSnapshot","limit":20}'
 ```
 
-5. Run deterministic module pattern gate (hard gate)
+6. Run deterministic module pattern gate (hard gate)
 
 ```bash
 bun skills/plaited-context/scripts/module-patterns.ts '{"files":["src/modules/example.ts"]}'
 ```
 
-6. Generate module flow review evidence
+7. Generate module flow review evidence
 
 ```bash
 bun skills/plaited-context/scripts/module-flow.ts '{"files":["src/modules/example.ts"],"format":"json"}'
@@ -105,13 +112,13 @@ bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/example.ts","oper
 bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/example.ts","operations":[{"type":"definition","line":120,"character":8}]}'
 ```
 
-7. Record findings with evidence
+8. Record findings with evidence
 
 ```bash
 bun skills/plaited-context/scripts/record-finding.ts '{"finding":{"kind":"anti-pattern","status":"candidate","summary":"Internal handlers should not catch ZodError locally.","evidence":[{"path":"src/modules/example.ts","line":100,"symbol":"server_start"}]}}'
 ```
 
-8. Export review JSON
+9. Export review JSON
 
 ```bash
 bun skills/plaited-context/scripts/export-review.ts '{"status":["candidate","validated"],"format":"json"}'
@@ -132,6 +139,18 @@ When sources conflict, prioritize:
 2. `AGENTS.md` operational instructions by scope
 3. skill instructions (`skills/*/SKILL.md`)
 4. wiki/reference docs (for synthesis and background)
+5. other indexed text
+
+`AGENTS.md` files are operational instructions, not wiki docs.
+
+Wiki docs are searchable synthesis/reference material and do not outrank code,
+`AGENTS.md`, or applicable skills.
+
+Wiki cleanup candidates are review evidence only; they are not automatic rewrite
+actions.
+
+Use `scan.ts`, `search.ts`, `context.ts`, and `wiki-context.ts` to assemble
+context instead of manually reading broad docs trees.
 
 ## Script Contracts
 

--- a/skills/plaited-context/assets/schema.sql
+++ b/skills/plaited-context/assets/schema.sql
@@ -73,6 +73,36 @@ CREATE TABLE IF NOT EXISTS docs (
 
 CREATE INDEX IF NOT EXISTS idx_docs_indexed_at ON docs(indexed_at DESC);
 
+CREATE TABLE IF NOT EXISTS doc_headings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  path TEXT NOT NULL,
+  heading TEXT NOT NULL,
+  level INTEGER NOT NULL CHECK (level BETWEEN 1 AND 6),
+  line INTEGER,
+  order_index INTEGER NOT NULL,
+  indexed_at TEXT NOT NULL,
+  FOREIGN KEY (path) REFERENCES docs(path) ON DELETE CASCADE,
+  UNIQUE (path, order_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_doc_headings_path ON doc_headings(path);
+CREATE INDEX IF NOT EXISTS idx_doc_headings_heading ON doc_headings(heading);
+
+CREATE TABLE IF NOT EXISTS doc_links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  path TEXT NOT NULL,
+  link_value TEXT NOT NULL,
+  link_text TEXT NOT NULL,
+  target_path TEXT,
+  target_exists INTEGER NOT NULL CHECK (target_exists IN (0, 1)),
+  indexed_at TEXT NOT NULL,
+  FOREIGN KEY (path) REFERENCES docs(path) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_doc_links_path ON doc_links(path);
+CREATE INDEX IF NOT EXISTS idx_doc_links_target_path ON doc_links(target_path);
+CREATE INDEX IF NOT EXISTS idx_doc_links_target_exists ON doc_links(target_exists);
+
 CREATE TABLE IF NOT EXISTS agent_instructions (
   path TEXT PRIMARY KEY,
   scope_path TEXT NOT NULL,

--- a/skills/plaited-context/scripts/context.ts
+++ b/skills/plaited-context/scripts/context.ts
@@ -28,6 +28,26 @@ export const ContextOutputSchema = z
     knownPatterns: z.array(z.string()).describe('Indexed validated patterns relevant to the task.'),
     knownAntiPatterns: z.array(z.string()).describe('Indexed anti-patterns relevant to the task.'),
     sourceOfTruth: z.array(z.string()).describe('Ordered high-authority references for decisions.'),
+    authorityOrder: z
+      .array(
+        z.object({
+          rank: z
+            .number()
+            .int()
+            .positive()
+            .describe('Authority precedence rank; lower numbers are stronger authority.'),
+          authority: z
+            .enum(['source', 'agent-instructions', 'skill', 'wiki', 'other'])
+            .describe('Authority source category.'),
+          label: z.string().min(1).describe('Short label for this authority layer.'),
+          description: z.string().min(1).describe('Human-readable summary for this authority layer.'),
+        }),
+      )
+      .describe('Explicit source authority precedence for conflict resolution.'),
+    authorityPolicy: z
+      .string()
+      .min(1)
+      .describe('Conflict policy describing why code/AGENTS/skills outrank wiki assertions.'),
     openQuestions: z.array(z.string()).describe('Open questions that need direct source confirmation.'),
   })
   .describe('Output contract for assembled operational task context.')

--- a/skills/plaited-context/scripts/export-review.ts
+++ b/skills/plaited-context/scripts/export-review.ts
@@ -43,6 +43,98 @@ const ExportedContextRunSchema = z
   })
   .describe('Recorded context assembly run included in export.')
 
+const ContextAuthorityEntrySchema = z
+  .object({
+    rank: z.number().int().positive().describe('Authority rank where lower is stronger.'),
+    authority: z
+      .enum(['source', 'agent-instructions', 'skill', 'wiki', 'other'])
+      .describe('Authority source classification.'),
+    label: z.string().min(1).describe('Short authority label.'),
+    description: z.string().min(1).describe('Authority explanation.'),
+  })
+  .describe('Single authority ordering entry.')
+
+const WikiBrokenLinkSchema = z
+  .object({
+    path: z.string().min(1).describe('Wiki page that contains the broken local link.'),
+    linkValue: z.string().min(1).describe('Raw markdown link value.'),
+    linkText: z.string().min(1).describe('Extracted display text for the link.'),
+    targetPath: z.string().nullable().describe('Normalized target path when resolvable.'),
+    reason: z.string().min(1).describe('Reason the link is treated as broken.'),
+    authority: z.literal('wiki').describe('Authority category for this warning.'),
+    provenance: z.array(z.string()).describe('Evidence paths used to produce this warning.'),
+  })
+  .describe('Broken wiki local-link evidence row.')
+
+const WikiCleanupCandidateSchema = z
+  .object({
+    path: z.string().min(1).describe('Wiki page path requiring cleanup review.'),
+    kind: z
+      .enum(['broken-local-link', 'missing-target-file', 'retired-skill-reference', 'orphan-page'])
+      .describe('Deterministic cleanup candidate kind.'),
+    reason: z.string().min(1).describe('Cleanup rationale.'),
+    authority: z.literal('wiki').describe('Authority category for this candidate.'),
+    provenance: z.array(z.string()).describe('Evidence references supporting the candidate.'),
+  })
+  .describe('Wiki cleanup candidate for human review.')
+
+const WikiContextPageSchema = z
+  .object({
+    path: z.string().min(1).describe('Wiki page path.'),
+    title: z.string().min(1).describe('Wiki page title (parsed or inferred).'),
+    reason: z.string().min(1).describe('Why this page is relevant to the task.'),
+    authority: z.literal('wiki').describe('Authority category for wiki pages.'),
+    headings: z.array(z.string()).describe('Captured markdown headings.'),
+    outboundLocalReferences: z.array(z.string()).describe('Captured outbound local references.'),
+    warnings: z.array(z.string()).describe('Cleanup warnings related to this page.'),
+    provenance: z
+      .object({
+        matchedTerms: z.array(z.string()).describe('Task terms that matched this page.'),
+        matchedIn: z
+          .array(z.enum(['path', 'title', 'heading', 'body', 'outbound-link', 'task-path']))
+          .describe('Fields where task-term matches were observed.'),
+      })
+      .describe('Deterministic relevance provenance.'),
+  })
+  .describe('Relevant wiki page entry.')
+
+const WikiContextSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates wiki context assembly completed successfully.'),
+    wikiPages: z.array(WikiContextPageSchema).describe('Relevant wiki pages for the task.'),
+    agentInstructions: z
+      .array(
+        z.object({
+          path: z.string().min(1).describe('AGENTS instruction file path.'),
+          scopePath: z.string().min(1).describe('Scoped path governed by this AGENTS file.'),
+          authority: z.literal('agent-instructions').describe('Authority category.'),
+          reason: z.string().min(1).describe('Reason this AGENTS file is relevant.'),
+          provenance: z.array(z.string()).describe('Deterministic relevance evidence.'),
+        }),
+      )
+      .describe('Relevant AGENTS operational instructions.'),
+    skills: z
+      .array(
+        z.object({
+          name: z.string().min(1).describe('Skill name.'),
+          path: z.string().min(1).describe('Skill path.'),
+          authority: z.literal('skill').describe('Authority category.'),
+          reason: z.string().min(1).describe('Reason this skill is relevant.'),
+          provenance: z.array(z.string()).describe('Deterministic relevance evidence.'),
+        }),
+      )
+      .describe('Relevant skills for this task.'),
+    sourceOfTruth: z.array(ContextAuthorityEntrySchema).describe('Explicit source authority ordering.'),
+    authorityPolicy: z
+      .string()
+      .min(1)
+      .describe('Conflict policy describing why code/AGENTS/skills outrank wiki assertions.'),
+    brokenLinks: z.array(WikiBrokenLinkSchema).describe('Broken wiki local-link evidence.'),
+    cleanupCandidates: z.array(WikiCleanupCandidateSchema).describe('Wiki cleanup candidate evidence.'),
+    openQuestions: z.array(z.string()).describe('Open follow-up questions for reviewers.'),
+  })
+  .describe('Wiki review context export for deterministic human review.')
+
 export const ExportReviewInputSchema = OperationalContextOverrideSchema.extend({
   status: z
     .array(FindingStatusSchema)
@@ -50,6 +142,9 @@ export const ExportReviewInputSchema = OperationalContextOverrideSchema.extend({
     .default(['candidate', 'validated', 'retired'])
     .describe('Finding statuses to include in the export.'),
   format: z.enum(['json']).default('json').describe('Export format.'),
+  wikiTask: z.string().min(1).default('review repository wiki context').describe('Wiki relevance task prompt.'),
+  wikiPaths: z.array(z.string().min(1)).default([]).describe('Optional task paths for wiki relevance scoping.'),
+  wikiLimit: z.number().int().positive().max(100).default(10).describe('Maximum wiki pages to include in review.'),
 }).describe('Input contract for exporting findings and context runs.')
 
 export const ExportReviewOutputSchema = z
@@ -60,20 +155,28 @@ export const ExportReviewOutputSchema = z
     exportedAt: z.string().min(1).describe('Export timestamp in ISO format.'),
     findings: z.array(ExportedFindingSchema).describe('Exported findings matching selected statuses.'),
     contextRuns: z.array(ExportedContextRunSchema).describe('Exported context run history.'),
+    wikiContext: WikiContextSchema.describe('Wiki review evidence and relevance context.'),
   })
   .describe('Output contract for review export.')
 
-export type ExportReviewInput = z.infer<typeof ExportReviewInputSchema>
+export type ExportReviewInput = z.input<typeof ExportReviewInputSchema>
 export type ExportReviewOutput = z.infer<typeof ExportReviewOutputSchema>
 
 export const exportReview = async (input: ExportReviewInput): Promise<ExportReviewOutput> => {
+  const status = input.status ?? ['candidate', 'validated', 'retired']
+  const wikiTask = input.wikiTask ?? 'review repository wiki context'
+  const wikiPaths = input.wikiPaths ?? []
+  const wikiLimit = input.wikiLimit ?? 10
   const context = await resolveOperationalContext(input)
   const db = await openContextDatabase({ dbPath: context.dbPath })
 
   try {
     const exported = exportReviewData({
       db,
-      statuses: input.status,
+      statuses: status,
+      wikiTask,
+      wikiPaths,
+      wikiLimit,
     })
 
     return {
@@ -83,6 +186,7 @@ export const exportReview = async (input: ExportReviewInput): Promise<ExportRevi
       exportedAt: new Date().toISOString(),
       findings: exported.findings,
       contextRuns: exported.contextRuns,
+      wikiContext: exported.wikiContext,
     }
   } finally {
     closeContextDatabase(db)

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -941,7 +941,7 @@ const parseDocLinks = async ({
       value: link.value,
       text: link.text,
       targetPath: normalizedTargetPath,
-      targetExists: true,
+      targetExists: normalizedTargetPath !== null,
     })
   }
 
@@ -1550,7 +1550,9 @@ const buildWikiCleanupReport = ({
 
   for (const row of linksRows) {
     const outboundSet = outboundByPath.get(row.path) ?? new Set<string>()
-    outboundSet.add(row.target_path ?? row.link_value)
+    if (row.target_exists === 1 && row.target_path) {
+      outboundSet.add(row.target_path)
+    }
     outboundByPath.set(row.path, outboundSet)
 
     if (row.target_path && docPaths.has(row.target_path)) {

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -6,9 +6,11 @@ import * as z from 'zod'
 import {
   findSkillDirectories,
   getSkillInstructionResourceLinks,
+  type LocalMarkdownLink,
   loadSkillCatalog,
   loadSkillFrontmatter,
   loadSkillInstructions,
+  validateMarkdownLocalLinks,
 } from '../../../src/cli.ts'
 
 const DEFAULT_DB_RELATIVE_PATH = '.plaited/context.sqlite'
@@ -112,6 +114,15 @@ export type SearchResultEntry = {
   snippet: string
 }
 
+export type ContextAuthority = 'source' | 'agent-instructions' | 'skill' | 'wiki' | 'other'
+
+export type ContextAuthorityEntry = {
+  rank: number
+  authority: ContextAuthority
+  label: string
+  description: string
+}
+
 export type ContextAssemblyOutput = {
   ok: true
   filesToRead: string[]
@@ -120,6 +131,74 @@ export type ContextAssemblyOutput = {
   knownPatterns: string[]
   knownAntiPatterns: string[]
   sourceOfTruth: string[]
+  authorityOrder: ContextAuthorityEntry[]
+  authorityPolicy: string
+  openQuestions: string[]
+}
+
+export type WikiBrokenLink = {
+  path: string
+  linkValue: string
+  linkText: string
+  targetPath: string | null
+  reason: string
+  authority: 'wiki'
+  provenance: string[]
+}
+
+export type WikiCleanupCandidateKind =
+  | 'broken-local-link'
+  | 'missing-target-file'
+  | 'retired-skill-reference'
+  | 'orphan-page'
+
+export type WikiCleanupCandidate = {
+  path: string
+  kind: WikiCleanupCandidateKind
+  reason: string
+  authority: 'wiki'
+  provenance: string[]
+}
+
+export type WikiContextPage = {
+  path: string
+  title: string
+  reason: string
+  authority: 'wiki'
+  headings: string[]
+  outboundLocalReferences: string[]
+  warnings: string[]
+  provenance: {
+    matchedTerms: string[]
+    matchedIn: Array<'path' | 'title' | 'heading' | 'body' | 'outbound-link' | 'task-path'>
+  }
+}
+
+export type WikiContextAgentInstruction = {
+  path: string
+  scopePath: string
+  authority: 'agent-instructions'
+  reason: string
+  provenance: string[]
+}
+
+export type WikiContextSkill = {
+  name: string
+  path: string
+  authority: 'skill'
+  reason: string
+  provenance: string[]
+}
+
+export type WikiContextOutput = {
+  ok: true
+  wikiPages: WikiContextPage[]
+  agentInstructions: WikiContextAgentInstruction[]
+  skills: WikiContextSkill[]
+  sourceOfTruth: ContextAuthorityEntry[]
+  authorityPolicy: string
+  brokenLinks: WikiBrokenLink[]
+  cleanupCandidates: WikiCleanupCandidate[]
   openQuestions: string[]
 }
 
@@ -140,6 +219,56 @@ type ExportRow = {
   kind: string
   line: number
 }
+
+type DocHeadingRow = {
+  heading: string
+  level: number
+  line: number
+  orderIndex: number
+}
+
+type DocLinkRow = {
+  value: string
+  text: string
+  targetPath: string | null
+  targetExists: boolean
+}
+
+export const CONTEXT_AUTHORITY_ORDER: ContextAuthorityEntry[] = [
+  {
+    rank: 1,
+    authority: 'source',
+    label: 'code',
+    description: 'src/ code and tests',
+  },
+  {
+    rank: 2,
+    authority: 'agent-instructions',
+    label: 'agent-instructions',
+    description: 'AGENTS.md operational instructions by path scope',
+  },
+  {
+    rank: 3,
+    authority: 'skill',
+    label: 'skills',
+    description: 'skills/*/SKILL.md and applicable skill scripts',
+  },
+  {
+    rank: 4,
+    authority: 'wiki',
+    label: 'wiki',
+    description: 'wiki/reference docs',
+  },
+  {
+    rank: 5,
+    authority: 'other',
+    label: 'other',
+    description: 'unclassified indexed text',
+  },
+]
+
+const AUTHORITY_POLICY_TEXT =
+  'When sources conflict, code and tests outrank AGENTS.md, AGENTS.md outranks skills, and skills outrank wiki.'
 
 let cachedSchemaSql: string | undefined
 
@@ -719,9 +848,117 @@ const toAgentInstructionScopePath = (relativePath: string): string => {
   return directory === '.' ? '.' : directory
 }
 
+const inferDocTitle = (relativePath: string): string => {
+  const stem = basename(relativePath, extname(relativePath))
+  const words = stem
+    .replace(/[-_]+/g, ' ')
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+
+  if (words.length === 0) {
+    return stem || relativePath
+  }
+
+  return words.map((word) => `${word[0]?.toUpperCase() ?? ''}${word.slice(1)}`).join(' ')
+}
+
+const parseMarkdownHeadings = (markdown: string): DocHeadingRow[] => {
+  const headings: DocHeadingRow[] = []
+  const lines = markdown.split(/\r?\n/)
+  let insideFence = false
+  let orderIndex = 0
+
+  for (const [index, rawLine] of lines.entries()) {
+    const line = rawLine.trim()
+    if (line.startsWith('```') || line.startsWith('~~~')) {
+      insideFence = !insideFence
+      continue
+    }
+    if (insideFence) {
+      continue
+    }
+
+    const match = rawLine.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/)
+    if (!match) {
+      continue
+    }
+
+    const hashes = match[1]
+    const heading = match[2]?.trim()
+    if (!hashes || !heading) {
+      continue
+    }
+
+    headings.push({
+      heading,
+      level: hashes.length,
+      line: index + 1,
+      orderIndex,
+    })
+    orderIndex += 1
+  }
+
+  return headings
+}
+
 const parseDocTitle = (markdown: string): string | undefined => {
-  const heading = markdown.match(/^#\s+(.+)$/m)
-  return heading?.[1]?.trim()
+  const heading = parseMarkdownHeadings(markdown)[0]
+  return heading?.heading
+}
+
+const sortLocalMarkdownLinks = (left: LocalMarkdownLink, right: LocalMarkdownLink): number => {
+  const valueComparison = left.value.localeCompare(right.value)
+  if (valueComparison !== 0) {
+    return valueComparison
+  }
+  return left.text.localeCompare(right.text)
+}
+
+const parseDocLinks = async ({
+  markdownBody,
+  absolutePath,
+  absoluteRoot,
+}: {
+  markdownBody: string
+  absolutePath: string
+  absoluteRoot: string
+}): Promise<DocLinkRow[]> => {
+  const baseDir = dirname(absolutePath)
+  const validation = await validateMarkdownLocalLinks({
+    baseDir,
+    markdownBody,
+  })
+  const present = [...validation.present].sort(sortLocalMarkdownLinks)
+  const missing = [...validation.missing].sort(sortLocalMarkdownLinks)
+  const rows: DocLinkRow[] = []
+
+  for (const link of present) {
+    const absoluteTargetPath = resolve(baseDir, link.value)
+    const normalizedTargetPath = isSubPath(absoluteTargetPath, absoluteRoot)
+      ? toPosix(relative(absoluteRoot, absoluteTargetPath))
+      : null
+    rows.push({
+      value: link.value,
+      text: link.text,
+      targetPath: normalizedTargetPath,
+      targetExists: true,
+    })
+  }
+
+  for (const link of missing) {
+    const absoluteTargetPath = resolve(baseDir, link.value)
+    const normalizedTargetPath = isSubPath(absoluteTargetPath, absoluteRoot)
+      ? toPosix(relative(absoluteRoot, absoluteTargetPath))
+      : null
+    rows.push({
+      value: link.value,
+      text: link.text,
+      targetPath: normalizedTargetPath,
+      targetExists: false,
+    })
+  }
+
+  return rows
 }
 
 export const indexWorkspace = async ({
@@ -774,10 +1011,19 @@ export const indexWorkspace = async ({
   const deleteFileAgentInstructions = db.query('DELETE FROM agent_instructions WHERE path = ?')
   const deleteFileSkill = db.query('DELETE FROM skills WHERE path = ?')
   const deleteFileDoc = db.query('DELETE FROM docs WHERE path = ?')
+  const deleteFileDocHeadings = db.query('DELETE FROM doc_headings WHERE path = ?')
+  const deleteFileDocLinks = db.query('DELETE FROM doc_links WHERE path = ?')
 
   const insertSymbol = db.query('INSERT INTO symbols (file_path, name, kind, line) VALUES (?, ?, ?, ?)')
   const insertImport = db.query('INSERT INTO imports (file_path, specifier, line, is_type) VALUES (?, ?, ?, ?)')
   const insertExport = db.query('INSERT INTO exports (file_path, name, kind, line) VALUES (?, ?, ?, ?)')
+  const insertDocHeading = db.query(
+    'INSERT INTO doc_headings (path, heading, level, line, order_index, indexed_at) VALUES (?, ?, ?, ?, ?, ?)',
+  )
+  const insertDocLink = db.query(
+    `INSERT INTO doc_links (path, link_value, link_text, target_path, target_exists, indexed_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
   const upsertSkill = db.query(
     `INSERT INTO skills (path, name, description, license, compatibility, indexed_at)
      VALUES (?, ?, ?, ?, ?, ?)
@@ -830,6 +1076,8 @@ export const indexWorkspace = async ({
     deleteFileAgentInstructions.run(relativePath)
     deleteFileSkill.run(relativePath)
     deleteFileDoc.run(relativePath)
+    deleteFileDocHeadings.run(relativePath)
+    deleteFileDocLinks.run(relativePath)
 
     const symbols = parseSymbols(content)
     const imports = parseImports(content)
@@ -868,7 +1116,21 @@ export const indexWorkspace = async ({
     }
 
     if (kind === 'wiki') {
-      upsertDoc.run(relativePath, parseDocTitle(content) ?? null, content, indexedAt)
+      const headings = parseMarkdownHeadings(content)
+      const links = await parseDocLinks({
+        markdownBody: content,
+        absolutePath,
+        absoluteRoot,
+      })
+
+      upsertDoc.run(relativePath, parseDocTitle(content) ?? inferDocTitle(relativePath), content, indexedAt)
+      for (const heading of headings) {
+        insertDocHeading.run(relativePath, heading.heading, heading.level, heading.line, heading.orderIndex, indexedAt)
+      }
+
+      for (const link of links) {
+        insertDocLink.run(relativePath, link.value, link.text, link.targetPath, link.targetExists ? 1 : 0, indexedAt)
+      }
       wikiIndexed += 1
     }
 
@@ -1171,7 +1433,10 @@ export const assembleContext = ({
     : mode === 'review'
       ? ['bun --bun tsc --noEmit', 'bun test <targeted-files-or-surface>']
       : mode === 'docs'
-        ? [`bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","docs","skills"]}'`]
+        ? [
+            `bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","docs","skills"]}'`,
+            `bun skills/plaited-context/scripts/wiki-context.ts '{"task":"<docs-task>","paths":["docs"],"limit":10}'`,
+          ]
         : [
             'bun --bun tsc --noEmit',
             'bun test <targeted-files-or-surface>',
@@ -1186,6 +1451,7 @@ export const assembleContext = ({
     ...skillPaths,
     'skills/*/SKILL.md (operational skill instructions)',
     'docs/ (wiki/reference; lower authority than code, AGENTS.md, and skills)',
+    'other indexed text (lowest authority)',
   ])
 
   const openQuestions: string[] = []
@@ -1204,6 +1470,471 @@ export const assembleContext = ({
     knownPatterns: findingPatternRows.map((row) => `${row.status}: ${row.summary}`),
     knownAntiPatterns: findingAntiPatternRows.map((row) => `${row.status}: ${row.summary}`),
     sourceOfTruth,
+    authorityOrder: CONTEXT_AUTHORITY_ORDER,
+    authorityPolicy: AUTHORITY_POLICY_TEXT,
+    openQuestions,
+  }
+}
+
+type WikiDocTableRow = {
+  path: string
+  title: string | null
+  body: string
+}
+
+type WikiHeadingTableRow = {
+  path: string
+  heading: string
+}
+
+type WikiLinkTableRow = {
+  path: string
+  link_value: string
+  link_text: string
+  target_path: string | null
+  target_exists: number
+}
+
+type SkillSearchRow = {
+  name: string
+  path: string
+}
+
+type AgentInstructionTableRow = {
+  path: string
+  scope_path: string
+}
+
+type WikiCleanupReport = {
+  brokenLinks: WikiBrokenLink[]
+  cleanupCandidates: WikiCleanupCandidate[]
+  warningsByPath: Map<string, string[]>
+  outboundByPath: Map<string, string[]>
+}
+
+const compareCleanupCandidates = (left: WikiCleanupCandidate, right: WikiCleanupCandidate): number => {
+  const pathComparison = left.path.localeCompare(right.path)
+  if (pathComparison !== 0) {
+    return pathComparison
+  }
+
+  const kindComparison = left.kind.localeCompare(right.kind)
+  if (kindComparison !== 0) {
+    return kindComparison
+  }
+
+  return left.reason.localeCompare(right.reason)
+}
+
+const buildWikiCleanupReport = ({
+  docsRows,
+  linksRows,
+  skillPaths,
+}: {
+  docsRows: WikiDocTableRow[]
+  linksRows: WikiLinkTableRow[]
+  skillPaths: Set<string>
+}): WikiCleanupReport => {
+  const docPaths = new Set(docsRows.map((row) => row.path))
+  const brokenLinks: WikiBrokenLink[] = []
+  const cleanupCandidates: WikiCleanupCandidate[] = []
+  const cleanupCandidateKeys = new Set<string>()
+  const warningsByPath = new Map<string, string[]>()
+  const outboundByPath = new Map<string, Set<string>>()
+  const incomingByPath = new Map<string, number>()
+
+  for (const docPath of docPaths) {
+    incomingByPath.set(docPath, 0)
+    outboundByPath.set(docPath, new Set())
+  }
+
+  for (const row of linksRows) {
+    const outboundSet = outboundByPath.get(row.path) ?? new Set<string>()
+    outboundSet.add(row.target_path ?? row.link_value)
+    outboundByPath.set(row.path, outboundSet)
+
+    if (row.target_path && docPaths.has(row.target_path)) {
+      incomingByPath.set(row.target_path, (incomingByPath.get(row.target_path) ?? 0) + 1)
+    }
+
+    if (row.target_exists === 1) {
+      continue
+    }
+
+    const isMissingTarget = row.target_path !== null
+    const reason = isMissingTarget
+      ? `Local link target '${row.target_path}' does not exist.`
+      : `Local link '${row.link_value}' cannot be resolved to a workspace path.`
+    brokenLinks.push({
+      path: row.path,
+      linkValue: row.link_value,
+      linkText: row.link_text,
+      targetPath: row.target_path,
+      reason,
+      authority: 'wiki',
+      provenance: ['doc-links'],
+    })
+
+    const kind: WikiCleanupCandidateKind = isMissingTarget ? 'missing-target-file' : 'broken-local-link'
+    const candidateKey = `${row.path}:${kind}:${row.link_value}:${row.target_path ?? '<none>'}`
+    if (cleanupCandidateKeys.has(candidateKey)) {
+      continue
+    }
+
+    cleanupCandidateKeys.add(candidateKey)
+    cleanupCandidates.push({
+      path: row.path,
+      kind,
+      reason,
+      authority: 'wiki',
+      provenance: [
+        `doc-links:${row.path}`,
+        row.target_path ? `missing-target:${row.target_path}` : `link-value:${row.link_value}`,
+      ],
+    })
+    warningsByPath.set(row.path, [...(warningsByPath.get(row.path) ?? []), reason])
+  }
+
+  for (const row of docsRows) {
+    const outgoingCount = outboundByPath.get(row.path)?.size ?? 0
+    const incomingCount = incomingByPath.get(row.path) ?? 0
+    if (outgoingCount === 0 && incomingCount === 0) {
+      const reason = 'Wiki page has no incoming or outgoing local links and may be orphaned.'
+      cleanupCandidates.push({
+        path: row.path,
+        kind: 'orphan-page',
+        reason,
+        authority: 'wiki',
+        provenance: ['doc-links:link-graph'],
+      })
+      warningsByPath.set(row.path, [...(warningsByPath.get(row.path) ?? []), reason])
+    }
+  }
+
+  const skillPathPattern = /\bskills\/[A-Za-z0-9._-]+\/SKILL\.md\b/g
+  for (const row of docsRows) {
+    const mentionedSkillPaths = new Set<string>()
+    for (const match of row.body.matchAll(skillPathPattern)) {
+      const value = match[0]
+      if (!value) {
+        continue
+      }
+      mentionedSkillPaths.add(toPosix(value))
+    }
+
+    for (const skillPath of [...mentionedSkillPaths].sort((left, right) => left.localeCompare(right))) {
+      if (skillPaths.has(skillPath)) {
+        continue
+      }
+
+      const reason = `Referenced skill path '${skillPath}' is not indexed as an active skill.`
+      const candidateKey = `${row.path}:retired-skill-reference:${skillPath}`
+      if (cleanupCandidateKeys.has(candidateKey)) {
+        continue
+      }
+
+      cleanupCandidateKeys.add(candidateKey)
+      cleanupCandidates.push({
+        path: row.path,
+        kind: 'retired-skill-reference',
+        reason,
+        authority: 'wiki',
+        provenance: [`doc-content:${skillPath}`],
+      })
+      warningsByPath.set(row.path, [...(warningsByPath.get(row.path) ?? []), reason])
+    }
+  }
+
+  const normalizedOutboundByPath = new Map<string, string[]>()
+  for (const [path, values] of outboundByPath.entries()) {
+    normalizedOutboundByPath.set(
+      path,
+      [...values].sort((left, right) => left.localeCompare(right)),
+    )
+  }
+
+  const normalizedWarningsByPath = new Map<string, string[]>()
+  for (const [path, warnings] of warningsByPath.entries()) {
+    normalizedWarningsByPath.set(
+      path,
+      [...new Set(warnings)].sort((left, right) => left.localeCompare(right)),
+    )
+  }
+
+  brokenLinks.sort((left, right) => {
+    const pathComparison = left.path.localeCompare(right.path)
+    if (pathComparison !== 0) {
+      return pathComparison
+    }
+    const valueComparison = left.linkValue.localeCompare(right.linkValue)
+    if (valueComparison !== 0) {
+      return valueComparison
+    }
+    return left.linkText.localeCompare(right.linkText)
+  })
+  cleanupCandidates.sort(compareCleanupCandidates)
+
+  return {
+    brokenLinks,
+    cleanupCandidates,
+    warningsByPath: normalizedWarningsByPath,
+    outboundByPath: normalizedOutboundByPath,
+  }
+}
+
+export const assembleWikiContext = ({
+  db,
+  task,
+  paths,
+  limit,
+}: {
+  db: Database
+  task: string
+  paths: string[]
+  limit: number
+}): WikiContextOutput => {
+  const docsRows = db
+    .query(
+      `SELECT path, title, body
+       FROM docs
+       ORDER BY path ASC`,
+    )
+    .all() as WikiDocTableRow[]
+
+  const headingsRows = db
+    .query(
+      `SELECT path, heading
+       FROM doc_headings
+       ORDER BY path ASC, order_index ASC`,
+    )
+    .all() as WikiHeadingTableRow[]
+
+  const linksRows = db
+    .query(
+      `SELECT path, link_value, link_text, target_path, target_exists
+       FROM doc_links
+       ORDER BY path ASC, link_value ASC, link_text ASC`,
+    )
+    .all() as WikiLinkTableRow[]
+
+  const skillPathRows = db
+    .query(
+      `SELECT path
+       FROM files
+       WHERE kind = 'skill'
+       ORDER BY path ASC`,
+    )
+    .all() as Array<{ path: string }>
+  const skillPaths = new Set(skillPathRows.map((row) => row.path))
+
+  const cleanupReport = buildWikiCleanupReport({
+    docsRows,
+    linksRows,
+    skillPaths,
+  })
+
+  const headingsByPath = new Map<string, string[]>()
+  for (const row of headingsRows) {
+    const headings = headingsByPath.get(row.path) ?? []
+    headings.push(row.heading)
+    headingsByPath.set(row.path, headings)
+  }
+
+  const terms = splitQueryTerms(task)
+  const searchTerms = (terms.length > 0 ? terms : [task]).map((term) => term.toLowerCase())
+  const normalizedTaskPaths = paths.map((path) => normalizeRelativePath(path)).filter((path) => path.length > 0)
+
+  const scoredPages = docsRows
+    .map((row) => {
+      const title = row.title?.trim() || inferDocTitle(row.path)
+      const headings = headingsByPath.get(row.path) ?? []
+      const outboundReferences = cleanupReport.outboundByPath.get(row.path) ?? []
+      const matchedTerms = new Set<string>()
+      const matchedIn = new Set<WikiContextPage['provenance']['matchedIn'][number]>()
+      let score = 0
+
+      const normalizedPath = row.path.toLowerCase()
+      const normalizedTitle = title.toLowerCase()
+      const normalizedHeadings = headings.map((heading) => heading.toLowerCase())
+      const normalizedBody = row.body.toLowerCase()
+      const normalizedOutboundReferences = outboundReferences.map((reference) => reference.toLowerCase())
+
+      for (const term of searchTerms) {
+        if (normalizedPath.includes(term)) {
+          matchedTerms.add(term)
+          matchedIn.add('path')
+          score += 3
+        }
+        if (normalizedTitle.includes(term)) {
+          matchedTerms.add(term)
+          matchedIn.add('title')
+          score += 4
+        }
+        if (normalizedHeadings.some((heading) => heading.includes(term))) {
+          matchedTerms.add(term)
+          matchedIn.add('heading')
+          score += 4
+        }
+        if (normalizedBody.includes(term)) {
+          matchedTerms.add(term)
+          matchedIn.add('body')
+          score += 1
+        }
+        if (normalizedOutboundReferences.some((reference) => reference.includes(term))) {
+          matchedTerms.add(term)
+          matchedIn.add('outbound-link')
+          score += 2
+        }
+      }
+
+      for (const taskPath of normalizedTaskPaths) {
+        if (pathScopesOverlap(row.path, taskPath)) {
+          matchedIn.add('task-path')
+          score += 2
+        }
+
+        if (outboundReferences.some((reference) => pathScopesOverlap(reference, taskPath))) {
+          matchedIn.add('task-path')
+          matchedIn.add('outbound-link')
+          score += 5
+        }
+      }
+
+      const warnings = cleanupReport.warningsByPath.get(row.path) ?? []
+      if (warnings.length > 0) {
+        score += 1
+      }
+
+      if (score === 0) {
+        return null
+      }
+
+      const reasonFragments: string[] = []
+      if (matchedIn.has('title') || matchedIn.has('heading')) {
+        reasonFragments.push('matched title/headings')
+      }
+      if (matchedIn.has('path')) {
+        reasonFragments.push('matched document path')
+      }
+      if (matchedIn.has('task-path')) {
+        reasonFragments.push('linked to requested task paths')
+      }
+      if (matchedIn.has('body')) {
+        reasonFragments.push('matched body terms')
+      }
+      if (warnings.length > 0) {
+        reasonFragments.push('contains cleanup warnings')
+      }
+
+      return {
+        page: {
+          path: row.path,
+          title,
+          reason: reasonFragments.join('; ') || 'matched wiki relevance terms',
+          authority: 'wiki' as const,
+          headings,
+          outboundLocalReferences: outboundReferences,
+          warnings,
+          provenance: {
+            matchedTerms: [...matchedTerms].sort((left, right) => left.localeCompare(right)),
+            matchedIn: [...matchedIn].sort((left, right) => left.localeCompare(right)),
+          },
+        },
+        score,
+      }
+    })
+    .filter((entry): entry is { page: WikiContextPage; score: number } => entry !== null)
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return right.score - left.score
+      }
+      return left.page.path.localeCompare(right.page.path)
+    })
+
+  const agentInstructionRows = db
+    .query(
+      `SELECT path, scope_path
+       FROM agent_instructions
+       ORDER BY CASE scope_path WHEN '.' THEN 0 ELSE 1 END, LENGTH(scope_path) DESC, path ASC`,
+    )
+    .all() as AgentInstructionTableRow[]
+  const relevantAgentInstructionPaths = new Set(getRelevantAgentInstructionPaths({ rows: agentInstructionRows, paths }))
+  const agentInstructions: WikiContextAgentInstruction[] = agentInstructionRows
+    .filter((row) => relevantAgentInstructionPaths.has(row.path))
+    .map((row) => ({
+      path: row.path,
+      scopePath: row.scope_path,
+      authority: 'agent-instructions',
+      reason:
+        row.scope_path === '.'
+          ? 'Root AGENTS.md applies across the workspace.'
+          : normalizedTaskPaths.length > 0
+            ? 'AGENTS scope overlaps requested paths.'
+            : 'Scoped AGENTS instruction included.',
+      provenance: [`scope:${row.scope_path}`],
+    }))
+
+  const skillMatchByPath = new Map<string, { name: string; path: string; matchedTerms: Set<string> }>()
+  for (const term of searchTerms) {
+    const likePattern = `%${escapeLike(term)}%`
+    const matches = db
+      .query(
+        `SELECT name, path
+         FROM skills
+         WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE OR description LIKE ? ESCAPE '\\' COLLATE NOCASE
+         ORDER BY name ASC
+         LIMIT 24`,
+      )
+      .all(likePattern, likePattern) as SkillSearchRow[]
+
+    for (const match of matches) {
+      const existing = skillMatchByPath.get(match.path)
+      if (existing) {
+        existing.matchedTerms.add(term)
+        continue
+      }
+
+      skillMatchByPath.set(match.path, {
+        name: match.name,
+        path: match.path,
+        matchedTerms: new Set([term]),
+      })
+    }
+  }
+
+  const skills = [...skillMatchByPath.values()]
+    .sort((left, right) => left.name.localeCompare(right.name) || left.path.localeCompare(right.path))
+    .map(
+      (entry): WikiContextSkill => ({
+        name: entry.name,
+        path: entry.path,
+        authority: 'skill',
+        reason: 'skill metadata matched task terms',
+        provenance: [...entry.matchedTerms].sort((left, right) => left.localeCompare(right)),
+      }),
+    )
+    .slice(0, Math.max(limit, 1))
+
+  const wikiPages = scoredPages.slice(0, Math.max(limit, 1)).map((entry) => entry.page)
+  const openQuestions: string[] = []
+  if (wikiPages.length === 0) {
+    openQuestions.push('No wiki pages matched the task terms. Confirm whether docs/ should be included in scan inputs.')
+  }
+  if (cleanupReport.cleanupCandidates.length > 0) {
+    openQuestions.push(
+      `${cleanupReport.cleanupCandidates.length} wiki cleanup candidates were found; review before relying on wiki assertions.`,
+    )
+  }
+
+  return {
+    ok: true,
+    wikiPages,
+    agentInstructions,
+    skills,
+    sourceOfTruth: CONTEXT_AUTHORITY_ORDER,
+    authorityPolicy: AUTHORITY_POLICY_TEXT,
+    brokenLinks: cleanupReport.brokenLinks,
+    cleanupCandidates: cleanupReport.cleanupCandidates,
     openQuestions,
   }
 }
@@ -1291,9 +2022,15 @@ export const recordContextRun = ({
 export const exportReviewData = ({
   db,
   statuses,
+  wikiTask,
+  wikiPaths,
+  wikiLimit,
 }: {
   db: Database
   statuses: FindingStatus[]
+  wikiTask: string
+  wikiPaths: string[]
+  wikiLimit: number
 }): {
   findings: Array<{
     id: number
@@ -1313,6 +2050,7 @@ export const exportReviewData = ({
     result: ContextAssemblyOutput | null
     createdAt: string
   }>
+  wikiContext: WikiContextOutput
 } => {
   const placeholders = statuses.map(() => '?').join(', ')
 
@@ -1378,6 +2116,13 @@ export const exportReviewData = ({
     created_at: string
   }>
 
+  const wikiContext = assembleWikiContext({
+    db,
+    task: wikiTask,
+    paths: wikiPaths,
+    limit: wikiLimit,
+  })
+
   return {
     findings: findings.map((finding) => ({
       id: finding.id,
@@ -1402,5 +2147,6 @@ export const exportReviewData = ({
         createdAt: row.created_at,
       }
     }),
+    wikiContext,
   }
 }

--- a/skills/plaited-context/scripts/tests/plaited-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/plaited-context.spec.ts
@@ -232,6 +232,8 @@ describe('plaited-context scripts', () => {
     expect(exportOutput.findings.length).toBe(1)
     expect(exportOutput.findings[0]?.summary).toContain('reportSnapshot')
     expect(exportOutput.contextRuns.length).toBeGreaterThan(0)
+    expect(exportOutput.wikiContext.ok).toBe(true)
+    expect(Array.isArray(exportOutput.wikiContext.cleanupCandidates)).toBe(true)
   })
 
   test('scan rejects include paths that escape rootDir and does not index outside files', async () => {
@@ -490,5 +492,14 @@ describe('plaited-context scripts', () => {
     expect(agentsIndex).toBeGreaterThan(sourceIndex)
     expect(skillsIndex).toBeGreaterThan(agentsIndex)
     expect(docsIndex).toBeGreaterThan(skillsIndex)
+
+    expect(contextOutput.authorityOrder.map((entry) => entry.authority)).toEqual([
+      'source',
+      'agent-instructions',
+      'skill',
+      'wiki',
+      'other',
+    ])
+    expect(contextOutput.authorityPolicy).toContain('outrank')
   })
 })

--- a/skills/plaited-context/scripts/tests/wiki-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/wiki-context.spec.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { initDb } from '../init-db.ts'
+import { closeContextDatabase, openContextDatabase } from '../plaited-context.ts'
+import { scanWorkspace } from '../scan.ts'
+import { assembleWikiTaskContext } from '../wiki-context.ts'
+
+const tempDirs: string[] = []
+
+const writeTempFile = async ({ path, content }: { path: string; content: string }) => {
+  await mkdir(dirname(path), { recursive: true })
+  await Bun.write(path, content)
+}
+
+const createWikiWorkspace = async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), 'plaited-context-wiki-'))
+  tempDirs.push(rootDir)
+
+  await writeTempFile({
+    path: join(rootDir, 'src/modules/runtime.ts'),
+    content: `export const runtimeModule = () => 'runtime'
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'AGENTS.md'),
+    content: `# Root Agent Instructions
+
+Operational scope for repository.
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'skills/example-skill/SKILL.md'),
+    content: `---
+name: example-skill
+description: Example skill for runtime review.
+license: ISC
+compatibility: Requires bun
+---
+
+# Example Skill
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'docs/guide.md'),
+    content: `# Runtime Guide
+
+## Module Layout
+
+Review [runtime module](../src/modules/runtime.ts#main) first.
+Check [missing note](./missing-note.md).
+See [example skill](../skills/example-skill/SKILL.md).
+Retired reference: \`skills/retired-skill/SKILL.md\`.
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'docs/index.md'),
+    content: `# Docs Index
+
+Start with [runtime guide](./guide.md).
+`,
+  })
+
+  await writeTempFile({
+    path: join(rootDir, 'docs/orphan.md'),
+    content: `# Orphan Doc
+
+No local links here.
+`,
+  })
+
+  return rootDir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('wiki-context assembly', () => {
+  test('indexes wiki markdown metadata while keeping AGENTS.md separate', async () => {
+    const rootDir = await createWikiWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({ cwd: rootDir, dbPath })
+    await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['AGENTS.md', 'src', 'skills', 'docs'],
+      force: true,
+    })
+
+    const db = await openContextDatabase({ dbPath })
+    try {
+      const guideFile = db.query(`SELECT kind FROM files WHERE path = 'docs/guide.md'`).get() as { kind: string } | null
+      const rootAgentsFile = db.query(`SELECT kind FROM files WHERE path = 'AGENTS.md'`).get() as {
+        kind: string
+      } | null
+      const guideDoc = db.query(`SELECT title FROM docs WHERE path = 'docs/guide.md'`).get() as { title: string } | null
+      const headings = db
+        .query(`SELECT heading FROM doc_headings WHERE path = 'docs/guide.md' ORDER BY order_index ASC`)
+        .all() as Array<{ heading: string }>
+      const links = db
+        .query(
+          `SELECT link_value, target_path, target_exists
+           FROM doc_links
+           WHERE path = 'docs/guide.md'
+           ORDER BY link_value ASC`,
+        )
+        .all() as Array<{ link_value: string; target_path: string | null; target_exists: number }>
+
+      expect(guideFile?.kind).toBe('wiki')
+      expect(rootAgentsFile?.kind).toBe('agent-instructions')
+      expect(guideDoc?.title).toBe('Runtime Guide')
+      expect(headings).toEqual([{ heading: 'Runtime Guide' }, { heading: 'Module Layout' }])
+      expect(links).toEqual([
+        {
+          link_value: '../skills/example-skill/SKILL.md',
+          target_path: 'skills/example-skill/SKILL.md',
+          target_exists: 1,
+        },
+        {
+          link_value: '../src/modules/runtime.ts',
+          target_path: 'src/modules/runtime.ts',
+          target_exists: 1,
+        },
+        {
+          link_value: 'missing-note.md',
+          target_path: 'docs/missing-note.md',
+          target_exists: 0,
+        },
+      ])
+    } finally {
+      closeContextDatabase(db)
+    }
+  })
+
+  test('reports deterministic wiki relevance, authority ordering, and cleanup candidates', async () => {
+    const rootDir = await createWikiWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({ cwd: rootDir, dbPath })
+    await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['AGENTS.md', 'src', 'skills', 'docs'],
+      force: true,
+    })
+
+    const firstOutput = await assembleWikiTaskContext({
+      cwd: rootDir,
+      dbPath,
+      task: 'review runtime module architecture',
+      paths: ['src/modules'],
+      limit: 10,
+    })
+    const secondOutput = await assembleWikiTaskContext({
+      cwd: rootDir,
+      dbPath,
+      task: 'review runtime module architecture',
+      paths: ['src/modules'],
+      limit: 10,
+    })
+
+    expect(firstOutput).toEqual(secondOutput)
+    expect(firstOutput.wikiPages.some((page) => page.path === 'docs/guide.md')).toBe(true)
+    expect(firstOutput.brokenLinks.some((link) => link.path === 'docs/guide.md')).toBe(true)
+    expect(firstOutput.cleanupCandidates.some((candidate) => candidate.kind === 'missing-target-file')).toBe(true)
+    expect(firstOutput.cleanupCandidates.some((candidate) => candidate.kind === 'retired-skill-reference')).toBe(true)
+    expect(firstOutput.cleanupCandidates.some((candidate) => candidate.kind === 'orphan-page')).toBe(true)
+    expect(firstOutput.authorityPolicy).toContain('outrank')
+    expect(firstOutput.sourceOfTruth.map((entry) => entry.authority)).toEqual([
+      'source',
+      'agent-instructions',
+      'skill',
+      'wiki',
+      'other',
+    ])
+  })
+
+  test('supports schema introspection for wiki-context script', async () => {
+    const inputSchemaText = (
+      await Bun.$`bun skills/plaited-context/scripts/wiki-context.ts --schema input`.cwd(process.cwd()).quiet()
+    ).stdout.toString()
+    const outputSchemaText = (
+      await Bun.$`bun skills/plaited-context/scripts/wiki-context.ts --schema output`.cwd(process.cwd()).quiet()
+    ).stdout.toString()
+
+    const inputSchema = JSON.parse(inputSchemaText) as {
+      properties?: Record<string, unknown>
+    }
+    const outputSchema = JSON.parse(outputSchemaText) as {
+      properties?: Record<string, unknown>
+    }
+
+    expect(inputSchema.properties?.task).toBeDefined()
+    expect(outputSchema.properties?.wikiPages).toBeDefined()
+    expect(outputSchema.properties?.cleanupCandidates).toBeDefined()
+  })
+})

--- a/skills/plaited-context/scripts/tests/wiki-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/wiki-context.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { initDb } from '../init-db.ts'
 import { closeContextDatabase, openContextDatabase } from '../plaited-context.ts'
 import { scanWorkspace } from '../scan.ts'
@@ -17,6 +17,9 @@ const writeTempFile = async ({ path, content }: { path: string; content: string 
 const createWikiWorkspace = async () => {
   const rootDir = await mkdtemp(join(tmpdir(), 'plaited-context-wiki-'))
   tempDirs.push(rootDir)
+  const outsideDir = await mkdtemp(join(tmpdir(), 'plaited-context-wiki-outside-'))
+  tempDirs.push(outsideDir)
+  const outsideLinkValue = `../../${basename(outsideDir)}/outside.md`
 
   await writeTempFile({
     path: join(rootDir, 'src/modules/runtime.ts'),
@@ -46,6 +49,12 @@ compatibility: Requires bun
   })
 
   await writeTempFile({
+    path: join(outsideDir, 'outside.md'),
+    content: `# Outside File
+`,
+  })
+
+  await writeTempFile({
     path: join(rootDir, 'docs/guide.md'),
     content: `# Runtime Guide
 
@@ -53,6 +62,7 @@ compatibility: Requires bun
 
 Review [runtime module](../src/modules/runtime.ts#main) first.
 Check [missing note](./missing-note.md).
+Check [outside workspace file](${outsideLinkValue}).
 See [example skill](../skills/example-skill/SKILL.md).
 Retired reference: \`skills/retired-skill/SKILL.md\`.
 `,
@@ -74,7 +84,10 @@ No local links here.
 `,
   })
 
-  return rootDir
+  return {
+    rootDir,
+    outsideLinkValue,
+  }
 }
 
 afterEach(async () => {
@@ -83,7 +96,7 @@ afterEach(async () => {
 
 describe('wiki-context assembly', () => {
   test('indexes wiki markdown metadata while keeping AGENTS.md separate', async () => {
-    const rootDir = await createWikiWorkspace()
+    const { rootDir, outsideLinkValue } = await createWikiWorkspace()
     const dbPath = join(rootDir, '.plaited/context.sqlite')
 
     await initDb({ cwd: rootDir, dbPath })
@@ -120,6 +133,11 @@ describe('wiki-context assembly', () => {
       expect(headings).toEqual([{ heading: 'Runtime Guide' }, { heading: 'Module Layout' }])
       expect(links).toEqual([
         {
+          link_value: outsideLinkValue,
+          target_path: null,
+          target_exists: 0,
+        },
+        {
           link_value: '../skills/example-skill/SKILL.md',
           target_path: 'skills/example-skill/SKILL.md',
           target_exists: 1,
@@ -141,7 +159,7 @@ describe('wiki-context assembly', () => {
   })
 
   test('reports deterministic wiki relevance, authority ordering, and cleanup candidates', async () => {
-    const rootDir = await createWikiWorkspace()
+    const { rootDir, outsideLinkValue } = await createWikiWorkspace()
     const dbPath = join(rootDir, '.plaited/context.sqlite')
 
     await initDb({ cwd: rootDir, dbPath })
@@ -171,9 +189,28 @@ describe('wiki-context assembly', () => {
     expect(firstOutput).toEqual(secondOutput)
     expect(firstOutput.wikiPages.some((page) => page.path === 'docs/guide.md')).toBe(true)
     expect(firstOutput.brokenLinks.some((link) => link.path === 'docs/guide.md')).toBe(true)
+    expect(
+      firstOutput.brokenLinks.some(
+        (link) =>
+          link.path === 'docs/guide.md' &&
+          link.linkValue === outsideLinkValue &&
+          link.reason.includes('cannot be resolved to a workspace path'),
+      ),
+    ).toBe(true)
     expect(firstOutput.cleanupCandidates.some((candidate) => candidate.kind === 'missing-target-file')).toBe(true)
+    expect(
+      firstOutput.cleanupCandidates.some(
+        (candidate) =>
+          candidate.path === 'docs/guide.md' &&
+          candidate.kind === 'broken-local-link' &&
+          candidate.reason.includes('cannot be resolved to a workspace path'),
+      ),
+    ).toBe(true)
     expect(firstOutput.cleanupCandidates.some((candidate) => candidate.kind === 'retired-skill-reference')).toBe(true)
     expect(firstOutput.cleanupCandidates.some((candidate) => candidate.kind === 'orphan-page')).toBe(true)
+    const guidePage = firstOutput.wikiPages.find((page) => page.path === 'docs/guide.md')
+    expect(guidePage).toBeDefined()
+    expect(guidePage?.outboundLocalReferences).not.toContain(outsideLinkValue)
     expect(firstOutput.authorityPolicy).toContain('outrank')
     expect(firstOutput.sourceOfTruth.map((entry) => entry.authority)).toEqual([
       'source',

--- a/skills/plaited-context/scripts/wiki-context.ts
+++ b/skills/plaited-context/scripts/wiki-context.ts
@@ -1,0 +1,146 @@
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  assembleWikiContext,
+  closeContextDatabase,
+  OperationalContextOverrideSchema,
+  openContextDatabase,
+  resolveOperationalContext,
+} from './plaited-context.ts'
+
+const WikiContextPageSchema = z
+  .object({
+    path: z.string().min(1).describe('Wiki page path.'),
+    title: z.string().min(1).describe('Parsed or inferred wiki title.'),
+    reason: z.string().min(1).describe('Deterministic relevance reason.'),
+    authority: z.literal('wiki').describe('Authority classification for wiki pages.'),
+    headings: z.array(z.string()).describe('Captured markdown headings.'),
+    outboundLocalReferences: z.array(z.string()).describe('Captured outbound local references.'),
+    warnings: z.array(z.string()).describe('Cleanup warnings for this page.'),
+    provenance: z
+      .object({
+        matchedTerms: z.array(z.string()).describe('Task terms that matched this page.'),
+        matchedIn: z
+          .array(z.enum(['path', 'title', 'heading', 'body', 'outbound-link', 'task-path']))
+          .describe('Fields where task terms matched.'),
+      })
+      .describe('Deterministic relevance provenance.'),
+  })
+  .describe('Wiki relevance entry.')
+
+const WikiContextAgentInstructionSchema = z
+  .object({
+    path: z.string().min(1).describe('AGENTS file path.'),
+    scopePath: z.string().min(1).describe('Scoped path for this instruction file.'),
+    authority: z.literal('agent-instructions').describe('Authority classification.'),
+    reason: z.string().min(1).describe('Reason this instruction file is relevant.'),
+    provenance: z.array(z.string()).describe('Deterministic evidence for inclusion.'),
+  })
+  .describe('Relevant AGENTS instruction entry.')
+
+const WikiContextSkillSchema = z
+  .object({
+    name: z.string().min(1).describe('Skill name.'),
+    path: z.string().min(1).describe('Skill path.'),
+    authority: z.literal('skill').describe('Authority classification.'),
+    reason: z.string().min(1).describe('Reason this skill is relevant.'),
+    provenance: z.array(z.string()).describe('Matched terms used for inclusion.'),
+  })
+  .describe('Relevant skill entry.')
+
+const ContextAuthoritySchema = z
+  .object({
+    rank: z.number().int().positive().describe('Authority rank where lower numbers are stronger authority.'),
+    authority: z
+      .enum(['source', 'agent-instructions', 'skill', 'wiki', 'other'])
+      .describe('Authority source category.'),
+    label: z.string().min(1).describe('Short authority label.'),
+    description: z.string().min(1).describe('Authority summary text.'),
+  })
+  .describe('Single source-of-truth authority layer.')
+
+const WikiBrokenLinkSchema = z
+  .object({
+    path: z.string().min(1).describe('Wiki page that contains the broken local link.'),
+    linkValue: z.string().min(1).describe('Raw markdown link value.'),
+    linkText: z.string().min(1).describe('Display text for the markdown link.'),
+    targetPath: z.string().nullable().describe('Normalized target path when resolvable.'),
+    reason: z.string().min(1).describe('Reason this link is considered broken.'),
+    authority: z.literal('wiki').describe('Authority category for wiki link warnings.'),
+    provenance: z.array(z.string()).describe('Deterministic evidence used for this warning.'),
+  })
+  .describe('Broken local-link report row.')
+
+const WikiCleanupCandidateSchema = z
+  .object({
+    path: z.string().min(1).describe('Wiki page path needing cleanup review.'),
+    kind: z
+      .enum(['broken-local-link', 'missing-target-file', 'retired-skill-reference', 'orphan-page'])
+      .describe('Cleanup candidate classification.'),
+    reason: z.string().min(1).describe('Cleanup recommendation reason.'),
+    authority: z.literal('wiki').describe('Authority category for cleanup candidates.'),
+    provenance: z.array(z.string()).describe('Deterministic evidence supporting this candidate.'),
+  })
+  .describe('Wiki cleanup recommendation entry.')
+
+export const WikiContextInputSchema = OperationalContextOverrideSchema.extend({
+  task: z.string().min(1).describe('Task statement used to rank wiki relevance.'),
+  paths: z.array(z.string().min(1)).default([]).describe('Optional task paths used for scope overlap ranking.'),
+  limit: z.number().int().positive().max(100).default(10).describe('Maximum wiki pages to return.'),
+}).describe('Input contract for deterministic wiki context assembly.')
+
+export const WikiContextOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates wiki context assembly succeeded.'),
+    wikiPages: z.array(WikiContextPageSchema).describe('Relevant wiki pages for the task.'),
+    agentInstructions: z
+      .array(WikiContextAgentInstructionSchema)
+      .describe('Applicable AGENTS operational instructions for the task scope.'),
+    skills: z.array(WikiContextSkillSchema).describe('Relevant skills discovered by task terms.'),
+    sourceOfTruth: z.array(ContextAuthoritySchema).describe('Explicit source authority order.'),
+    authorityPolicy: z
+      .string()
+      .min(1)
+      .describe('Conflict policy describing why code/AGENTS/skills outrank wiki assertions.'),
+    brokenLinks: z.array(WikiBrokenLinkSchema).describe('Broken wiki local-link evidence rows.'),
+    cleanupCandidates: z.array(WikiCleanupCandidateSchema).describe('Deterministic wiki cleanup candidates.'),
+    openQuestions: z.array(z.string()).describe('Open questions requiring human review.'),
+  })
+  .describe('Output contract for wiki-oriented context assembly.')
+
+export type WikiContextInput = z.infer<typeof WikiContextInputSchema>
+export type WikiContextOutput = z.infer<typeof WikiContextOutputSchema>
+
+export const assembleWikiTaskContext = async (input: WikiContextInput): Promise<WikiContextOutput> => {
+  const { task, paths, limit, ...contextOverrides } = input
+  const context = await resolveOperationalContext(contextOverrides)
+  const db = await openContextDatabase({ dbPath: context.dbPath })
+
+  try {
+    return assembleWikiContext({
+      db,
+      task,
+      paths,
+      limit,
+    })
+  } finally {
+    closeContextDatabase(db)
+  }
+}
+
+export const wikiContextCli = makeCli({
+  name: 'skills/plaited-context/scripts/wiki-context.ts',
+  inputSchema: WikiContextInputSchema,
+  outputSchema: WikiContextOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/wiki-context.ts '{"task":"review runtime module architecture","paths":["src/modules"],"limit":10}'`,
+    `  bun skills/plaited-context/scripts/wiki-context.ts --schema input`,
+    `  bun skills/plaited-context/scripts/wiki-context.ts --schema output`,
+  ].join('\n'),
+  run: assembleWikiTaskContext,
+})
+
+if (import.meta.main) {
+  await wikiContextCli(Bun.argv.slice(2))
+}


### PR DESCRIPTION
## Context

- Fixes #320
- Add Slice 3 wiki context assembly to `plaited-context` with deterministic provenance and cleanup evidence.

## Summary

- Added wiki metadata indexing for markdown docs: headings and local link graph (`doc_headings`, `doc_links`).
- Kept `AGENTS.md` separate as `agent-instructions` and surfaced authority order/policy explicitly.
- Added deterministic wiki context assembly in `plaited-context.ts`.
- Added new script `skills/plaited-context/scripts/wiki-context.ts` with JSON input/output and `--schema input|output`.
- Extended `export-review.ts` output with `wikiContext` (relevant pages, broken links, cleanup candidates, provenance, open questions).
- Updated `skills/plaited-context/SKILL.md` to document wiki usage and authority boundaries.
- Added focused wiki tests covering indexing/classification, heading/link capture, cleanup candidates, deterministic output, and schema introspection.

## Changed Files

- skills/plaited-context/SKILL.md
- skills/plaited-context/assets/schema.sql
- skills/plaited-context/scripts/context.ts
- skills/plaited-context/scripts/export-review.ts
- skills/plaited-context/scripts/plaited-context.ts
- skills/plaited-context/scripts/wiki-context.ts
- skills/plaited-context/scripts/tests/plaited-context.spec.ts
- skills/plaited-context/scripts/tests/wiki-context.spec.ts

## Validation

- Targeted tests:
  - `bun test skills/plaited-context/scripts/tests`
  - `bun test src/cli/utils/tests/markdown.spec.ts`
  - `bun bin/plaited.ts skills-validate '{"skillPath":"skills/plaited-context/SKILL.md"}'`
  - `bun bin/plaited.ts skills-links '{"rootDir":".","path":"skills/plaited-context"}'`
  - `bun skills/plaited-context/scripts/init-db.ts '{"dbPath":"/tmp/plaited-context-wiki-slice.sqlite"}'`
  - `bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","dbPath":"/tmp/plaited-context-wiki-slice.sqlite","include":["AGENTS.md","src","skills","docs"],"force":true}'`
  - `bun skills/plaited-context/scripts/context.ts '{"dbPath":"/tmp/plaited-context-wiki-slice.sqlite","task":"review runtime module architecture","mode":"review","paths":["src/modules"]}'`
  - `bun skills/plaited-context/scripts/wiki-context.ts '{"dbPath":"/tmp/plaited-context-wiki-slice.sqlite","task":"review runtime module architecture","paths":["src/modules"],"limit":10}'`
  - `bun skills/plaited-context/scripts/wiki-context.ts --schema input`
  - `bun skills/plaited-context/scripts/wiki-context.ts --schema output`
- `bun --bun tsc --noEmit`: pass

## Known Failures / Drift

- None found in this slice.

## Review Notes / Residual Risks

- Orphan-page reporting is intentionally broad and evidence-only; it is not a hard failure gate.
- Retired skill detection is deterministic pattern matching (`skills/<name>/SKILL.md`) and does not perform semantic truth validation.
- This slice intentionally does not add embeddings, remote model calls, autonomous rewriting, or background agents.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
