### PR TITLE
feat(skills): add local read-only git context to plaited-context

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -40,6 +40,16 @@ git fetch origin dev
 git merge --ff-only origin/dev
 ```
 
+- Dedicated worktree coding sessions should normally end in a commit for the
+  completed coherent body of work before final handoff.
+- Do not auto-commit review-only work, exploratory work, ignored/local prompt
+  edits, or intentionally partial work unless the maintainer explicitly requests
+  it.
+- Final handoff should include branch, commit SHA, validation run summary, and
+  PR link when a PR is opened.
+- Do not automatically merge worktree branches into `dev`; that remains an
+  explicit integration action.
+
 - `dev -> main` release PRs should squash-merge.
 - After any squash release from `dev -> main`, sync `main` back into `dev` using a merge commit.
 - Never reset/rebase/force-push `dev`.

--- a/skills/plaited-context/SKILL.md
+++ b/skills/plaited-context/SKILL.md
@@ -19,6 +19,7 @@ Use it before:
 
 - implementing a feature or fix
 - reviewing a slice or PR
+- reviewing agent-authored worktree state before PR handoff
 - updating wiki/reference docs and checking for stale guidance
 - large code, docs, or skill edits that need source-grounded context first
 
@@ -112,13 +113,21 @@ bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/example.ts","oper
 bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/example.ts","operations":[{"type":"definition","line":120,"character":8}]}'
 ```
 
-8. Record findings with evidence
+8. Assemble local read-only Git context for review/planning evidence
+
+```bash
+bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["skills/plaited-context"],"includeWorktrees":true}'
+bun skills/plaited-context/scripts/git-history.ts '{"base":"origin/dev","paths":["skills/plaited-context"],"limit":20}'
+bun skills/plaited-context/scripts/git-worktrees.ts '{}'
+```
+
+9. Record findings with evidence
 
 ```bash
 bun skills/plaited-context/scripts/record-finding.ts '{"finding":{"kind":"anti-pattern","status":"candidate","summary":"Internal handlers should not catch ZodError locally.","evidence":[{"path":"src/modules/example.ts","line":100,"symbol":"server_start"}]}}'
 ```
 
-9. Export review JSON
+10. Export review JSON
 
 ```bash
 bun skills/plaited-context/scripts/export-review.ts '{"status":["candidate","validated"],"format":"json"}'
@@ -151,6 +160,21 @@ actions.
 
 Use `scan.ts`, `search.ts`, `context.ts`, and `wiki-context.ts` to assemble
 context instead of manually reading broad docs trees.
+
+## Git Context Scope
+
+Git context in this skill is read-only evidence for review and planning:
+
+- local branch/HEAD/upstream state
+- worktree state and possible stale/prunable branches
+- merge-base, commits since base, changed files since base
+- path-specific recent commit history
+
+Git context augments code/test/skill/wiki context; it does not replace source
+or test evidence and does not override `AGENTS.md`.
+
+Git context commands in this skill do not authorize merge/rebase/reset/stash
+mutation, branch deletion, or worktree removal.
 
 ## Script Contracts
 

--- a/skills/plaited-context/scripts/git-context.shared.ts
+++ b/skills/plaited-context/scripts/git-context.shared.ts
@@ -1,0 +1,571 @@
+import { stat } from 'node:fs/promises'
+import { isAbsolute, relative, resolve } from 'node:path'
+import * as z from 'zod'
+
+const toPosix = (value: string) => value.replace(/\\/g, '/')
+
+const quoteArg = (value: string) => {
+  if (value === '') {
+    return "''"
+  }
+
+  if (/^[A-Za-z0-9_./:@=+-]+$/.test(value)) {
+    return value
+  }
+
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+export const formatGitCommand = (args: string[]): string => ['git', ...args].map((arg) => quoteArg(arg)).join(' ')
+
+export class GitCommandError extends Error {
+  readonly code = 'GIT_COMMAND_FAILED'
+  readonly command: string
+  readonly exitCode: number
+  readonly stderr: string
+
+  constructor({ command, exitCode, stderr }: { command: string; exitCode: number; stderr: string }) {
+    super(`Git command failed (${exitCode}): ${command}`)
+    this.command = command
+    this.exitCode = exitCode
+    this.stderr = stderr
+  }
+}
+
+export const GitCommitSchema = z
+  .object({
+    fullSha: z.string().min(1).describe('Full commit SHA.'),
+    shortSha: z.string().min(1).describe('Short commit SHA for quick inspection.'),
+    committedAt: z.string().min(1).describe('Commit timestamp in ISO format.'),
+    subject: z.string().min(1).describe('Commit subject line.'),
+  })
+  .describe('Commit summary entry.')
+
+export const GitChangedFileSchema = z
+  .object({
+    status: z.enum(['A', 'C', 'D', 'M', 'R', 'T', 'U', 'X']).describe('Normalized one-letter Git change status.'),
+    rawStatus: z.string().min(1).describe('Raw Git status token, including rename/copy score when present.'),
+    path: z.string().min(1).describe('Changed path relative to the repository root.'),
+    oldPath: z.string().min(1).optional().describe('Previous path for rename/copy entries.'),
+  })
+  .describe('Changed file entry from a Git diff.')
+
+export const GitPathHistoryEntrySchema = z
+  .object({
+    path: z.string().min(1).describe('Validated path relative to the repository root.'),
+    commits: z.array(GitCommitSchema).describe('Most recent commits touching this path.'),
+  })
+  .describe('Per-path recent commit history entry.')
+
+export const GitWorktreeEntrySchema = z
+  .object({
+    path: z.string().min(1).describe('Absolute worktree path.'),
+    head: z.string().min(1).describe('HEAD commit SHA for the worktree.'),
+    branch: z.string().nullable().describe('Branch ref for this worktree when attached; null when detached.'),
+    detached: z.boolean().describe('True when the worktree is detached.'),
+    bare: z.boolean().describe('True when the worktree is bare.'),
+    lockedReason: z.string().nullable().describe('Lock reason when present.'),
+    prunableReason: z.string().nullable().describe('Prunable reason when reported by Git.'),
+    exists: z.boolean().describe('True when the worktree path exists on disk.'),
+    isCurrent: z.boolean().describe('True when this is the current worktree.'),
+  })
+  .describe('Parsed worktree metadata from `git worktree list --porcelain`.')
+
+export type GitCommit = z.infer<typeof GitCommitSchema>
+export type GitChangedFile = z.infer<typeof GitChangedFileSchema>
+export type GitPathHistoryEntry = z.infer<typeof GitPathHistoryEntrySchema>
+export type GitWorktreeEntry = z.infer<typeof GitWorktreeEntrySchema>
+
+const isSubPath = (candidate: string, rootPath: string): boolean => {
+  const relativePath = relative(rootPath, candidate)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+const trimRef = (value: string) => value.trim()
+
+const parseGitLogRows = (stdout: string): GitCommit[] => {
+  if (!stdout.trim()) {
+    return []
+  }
+
+  const commits: GitCommit[] = []
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const [fullSha = '', shortSha = '', committedAt = '', ...subjectParts] = trimmed.split('\t')
+    const subject = subjectParts.join('\t').trim()
+    if (!fullSha || !shortSha || !committedAt || !subject) {
+      continue
+    }
+    commits.push({
+      fullSha,
+      shortSha,
+      committedAt,
+      subject,
+    })
+  }
+
+  return commits
+}
+
+const parseNameStatusRows = (stdout: string): GitChangedFile[] => {
+  if (!stdout.trim()) {
+    return []
+  }
+
+  const changed: GitChangedFile[] = []
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line) {
+      continue
+    }
+
+    const parts = line.split('\t')
+    const rawStatus = parts[0]?.trim() ?? ''
+    const normalizedStatus = rawStatus[0] as GitChangedFile['status'] | undefined
+    if (!rawStatus || !normalizedStatus || !['A', 'C', 'D', 'M', 'R', 'T', 'U', 'X'].includes(normalizedStatus)) {
+      continue
+    }
+
+    if ((normalizedStatus === 'R' || normalizedStatus === 'C') && parts.length >= 3) {
+      const oldPath = parts[1]?.trim()
+      const path = parts[2]?.trim()
+      if (!oldPath || !path) {
+        continue
+      }
+      changed.push({
+        status: normalizedStatus,
+        rawStatus,
+        path,
+        oldPath,
+      })
+      continue
+    }
+
+    const path = parts[1]?.trim()
+    if (!path) {
+      continue
+    }
+
+    changed.push({
+      status: normalizedStatus,
+      rawStatus,
+      path,
+    })
+  }
+
+  return changed
+}
+
+const pathExists = async (value: string): Promise<boolean> => {
+  try {
+    await stat(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const runGit = async ({
+  cwd,
+  args,
+  allowFailure = false,
+}: {
+  cwd: string
+  args: string[]
+  allowFailure?: boolean
+}): Promise<{
+  stdout: string
+  stderr: string
+  exitCode: number
+  command: string
+}> => {
+  const command = formatGitCommand(args)
+  const result = await Bun.$`git ${args}`.cwd(cwd).quiet().nothrow()
+  const stdout = result.stdout.toString().trimEnd()
+  const stderr = result.stderr.toString().trim()
+  if (result.exitCode !== 0 && !allowFailure) {
+    throw new GitCommandError({
+      command,
+      exitCode: result.exitCode,
+      stderr,
+    })
+  }
+
+  return {
+    stdout,
+    stderr,
+    exitCode: result.exitCode,
+    command,
+  }
+}
+
+export const resolveGitRepoRoot = async (cwd: string): Promise<string> => {
+  const result = await runGit({
+    cwd,
+    args: ['rev-parse', '--show-toplevel'],
+  })
+  return resolve(result.stdout.trim())
+}
+
+export const resolvePathWithinRepo = ({ repoRoot, value }: { repoRoot: string; value: string }): string => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error(`Invalid path '${value}': empty paths are not allowed.`)
+  }
+
+  const absolute = isAbsolute(trimmed) ? resolve(trimmed) : resolve(repoRoot, trimmed)
+  if (!isSubPath(absolute, repoRoot)) {
+    throw new Error(`Invalid path '${value}': path escapes repository root.`)
+  }
+
+  const relativePath = toPosix(relative(repoRoot, absolute))
+  return relativePath === '' ? '.' : relativePath
+}
+
+export const resolvePathListWithinRepo = ({ repoRoot, paths }: { repoRoot: string; paths: string[] }): string[] => {
+  const entries = new Set<string>()
+  for (const path of paths) {
+    entries.add(resolvePathWithinRepo({ repoRoot, value: path }))
+  }
+  return [...entries]
+}
+
+export const resolveGitRef = async ({ cwd, ref }: { cwd: string; ref: string }): Promise<string | null> => {
+  const resolved = await runGit({
+    cwd,
+    args: ['rev-parse', '--verify', `${ref}^{commit}`],
+    allowFailure: true,
+  })
+  if (resolved.exitCode !== 0) {
+    return null
+  }
+
+  return trimRef(resolved.stdout)
+}
+
+export const collectCommits = async ({
+  cwd,
+  range,
+  limit,
+}: {
+  cwd: string
+  range: string
+  limit: number
+}): Promise<GitCommit[]> => {
+  const logResult = await runGit({
+    cwd,
+    args: ['log', '--no-decorate', '--date=iso-strict', '--pretty=format:%H%x09%h%x09%cI%x09%s', `-n${limit}`, range],
+  })
+  return parseGitLogRows(logResult.stdout)
+}
+
+export const collectPathHistory = async ({
+  cwd,
+  paths,
+  limit,
+}: {
+  cwd: string
+  paths: string[]
+  limit: number
+}): Promise<GitPathHistoryEntry[]> => {
+  const histories: GitPathHistoryEntry[] = []
+  for (const path of paths) {
+    const logResult = await runGit({
+      cwd,
+      args: [
+        'log',
+        '--no-decorate',
+        '--date=iso-strict',
+        '--pretty=format:%H%x09%h%x09%cI%x09%s',
+        `-n${limit}`,
+        '--',
+        path,
+      ],
+    })
+
+    histories.push({
+      path,
+      commits: parseGitLogRows(logResult.stdout),
+    })
+  }
+
+  return histories
+}
+
+export const collectChangedFiles = async ({
+  cwd,
+  mergeBase,
+}: {
+  cwd: string
+  mergeBase: string
+}): Promise<GitChangedFile[]> => {
+  const diffResult = await runGit({
+    cwd,
+    args: ['diff', '--name-status', `${mergeBase}...HEAD`],
+  })
+  return parseNameStatusRows(diffResult.stdout)
+}
+
+export const resolveMergeBase = async ({ cwd, baseRef }: { cwd: string; baseRef: string }): Promise<string | null> => {
+  const mergeBaseResult = await runGit({
+    cwd,
+    args: ['merge-base', 'HEAD', baseRef],
+    allowFailure: true,
+  })
+
+  if (mergeBaseResult.exitCode !== 0) {
+    return null
+  }
+
+  return mergeBaseResult.stdout.trim()
+}
+
+type ParsedWorktreeAccumulator = {
+  path: string
+  head: string
+  branch: string | null
+  detached: boolean
+  bare: boolean
+  lockedReason: string | null
+  prunableReason: string | null
+}
+
+const createWorktreeAccumulator = (path: string): ParsedWorktreeAccumulator => ({
+  path,
+  head: '',
+  branch: null,
+  detached: false,
+  bare: false,
+  lockedReason: null,
+  prunableReason: null,
+})
+
+const parseWorktreeList = (stdout: string): ParsedWorktreeAccumulator[] => {
+  const parsed: ParsedWorktreeAccumulator[] = []
+  let current: ParsedWorktreeAccumulator | null = null
+
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue
+    }
+
+    if (line.startsWith('worktree ')) {
+      if (current) {
+        parsed.push(current)
+      }
+      current = createWorktreeAccumulator(line.slice('worktree '.length))
+      continue
+    }
+
+    if (!current) {
+      continue
+    }
+
+    if (line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length).trim()
+      continue
+    }
+    if (line.startsWith('branch ')) {
+      current.branch = line.slice('branch '.length).trim()
+      continue
+    }
+    if (line === 'detached') {
+      current.detached = true
+      continue
+    }
+    if (line === 'bare') {
+      current.bare = true
+      continue
+    }
+    if (line === 'locked') {
+      current.lockedReason = ''
+      continue
+    }
+    if (line.startsWith('locked ')) {
+      current.lockedReason = line.slice('locked '.length)
+      continue
+    }
+    if (line === 'prunable') {
+      current.prunableReason = ''
+      continue
+    }
+    if (line.startsWith('prunable ')) {
+      current.prunableReason = line.slice('prunable '.length)
+    }
+  }
+
+  if (current) {
+    parsed.push(current)
+  }
+
+  return parsed
+}
+
+export const collectWorktrees = async ({
+  cwd,
+  currentWorktree,
+}: {
+  cwd: string
+  currentWorktree: string
+}): Promise<GitWorktreeEntry[]> => {
+  const worktreeResult = await runGit({
+    cwd,
+    args: ['worktree', 'list', '--porcelain'],
+  })
+  const parsed = parseWorktreeList(worktreeResult.stdout)
+
+  const rows: GitWorktreeEntry[] = []
+  for (const entry of parsed) {
+    const absolutePath = resolve(entry.path)
+    rows.push({
+      path: absolutePath,
+      head: entry.head,
+      branch: entry.branch,
+      detached: entry.detached,
+      bare: entry.bare,
+      lockedReason: entry.lockedReason,
+      prunableReason: entry.prunableReason,
+      exists: await pathExists(absolutePath),
+      isCurrent: absolutePath === currentWorktree,
+    })
+  }
+
+  return rows
+}
+
+export const collectDirtyState = async ({
+  cwd,
+}: {
+  cwd: string
+}): Promise<{
+  stagedFiles: string[]
+  unstagedFiles: string[]
+  untrackedFiles: string[]
+}> => {
+  const statusResult = await runGit({
+    cwd,
+    args: ['status', '--porcelain', '--branch'],
+  })
+
+  const stagedFiles = new Set<string>()
+  const unstagedFiles = new Set<string>()
+  const untrackedFiles = new Set<string>()
+  const lines = statusResult.stdout.split(/\r?\n/)
+
+  for (const line of lines) {
+    if (!line || line.startsWith('## ')) {
+      continue
+    }
+
+    if (line.startsWith('?? ')) {
+      const path = line.slice(3).trim()
+      if (path) {
+        untrackedFiles.add(path)
+      }
+      continue
+    }
+
+    if (line.startsWith('!! ')) {
+      continue
+    }
+
+    const x = line[0] ?? ' '
+    const y = line[1] ?? ' '
+    const rawPath = line.slice(3).trim()
+    if (!rawPath) {
+      continue
+    }
+
+    const path = rawPath.includes(' -> ') ? (rawPath.split(' -> ').at(-1)?.trim() ?? rawPath) : rawPath
+    if (x !== ' ') {
+      stagedFiles.add(path)
+    }
+    if (y !== ' ') {
+      unstagedFiles.add(path)
+    }
+  }
+
+  return {
+    stagedFiles: [...stagedFiles].sort(),
+    unstagedFiles: [...unstagedFiles].sort(),
+    untrackedFiles: [...untrackedFiles].sort(),
+  }
+}
+
+export const resolveCurrentBranch = async ({ cwd }: { cwd: string }): Promise<string | null> => {
+  const branch = await runGit({
+    cwd,
+    args: ['branch', '--show-current'],
+  })
+  const value = branch.stdout.trim()
+  return value ? value : null
+}
+
+export const resolveHead = async ({ cwd }: { cwd: string }): Promise<string> => {
+  const head = await runGit({
+    cwd,
+    args: ['rev-parse', 'HEAD'],
+  })
+  return head.stdout.trim()
+}
+
+export const resolveUpstream = async ({ cwd }: { cwd: string }): Promise<string | null> => {
+  const upstream = await runGit({
+    cwd,
+    args: ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    allowFailure: true,
+  })
+  if (upstream.exitCode !== 0) {
+    return null
+  }
+  const value = upstream.stdout.trim()
+  return value ? value : null
+}
+
+export const buildStructuredCliError = (
+  error: unknown,
+): {
+  ok: false
+  error: {
+    code: string
+    message: string
+    command?: string
+    exitCode?: number
+    stderr?: string
+  }
+} => {
+  if (error instanceof GitCommandError) {
+    return {
+      ok: false,
+      error: {
+        code: error.code,
+        message: error.message,
+        command: error.command,
+        exitCode: error.exitCode,
+        stderr: error.stderr,
+      },
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      ok: false,
+      error: {
+        code: 'UNKNOWN_ERROR',
+        message: error.message,
+      },
+    }
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'UNKNOWN_ERROR',
+      message: 'Unknown error',
+    },
+  }
+}

--- a/skills/plaited-context/scripts/git-context.shared.ts
+++ b/skills/plaited-context/scripts/git-context.shared.ts
@@ -16,7 +16,9 @@ const quoteArg = (value: string) => {
   return `'${value.replaceAll("'", "'\\''")}'`
 }
 
-export const formatGitCommand = (args: string[]): string => ['git', ...args].map((arg) => quoteArg(arg)).join(' ')
+export const formatShellCommand = (argv: string[]): string => argv.map((arg) => quoteArg(arg)).join(' ')
+
+export const formatGitCommand = (args: string[]): string => formatShellCommand(['git', ...args])
 
 export class GitCommandError extends Error {
   readonly code = 'GIT_COMMAND_FAILED'

--- a/skills/plaited-context/scripts/git-context.ts
+++ b/skills/plaited-context/scripts/git-context.ts
@@ -1,0 +1,185 @@
+import { resolve } from 'node:path'
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  buildStructuredCliError,
+  collectDirtyState,
+  GitChangedFileSchema,
+  GitCommitSchema,
+  GitPathHistoryEntrySchema,
+  GitWorktreeEntrySchema,
+  resolveCurrentBranch,
+  resolveGitRepoRoot,
+  resolveHead,
+  resolveUpstream,
+} from './git-context.shared.ts'
+import { collectGitHistory, GitHistoryInputSchema } from './git-history.ts'
+import { collectGitWorktrees, GitWorktreesInputSchema } from './git-worktrees.ts'
+
+const DirtySummarySchema = z
+  .object({
+    isDirty: z.boolean().describe('True when staged, unstaged, or untracked files are present.'),
+    stagedCount: z.number().int().nonnegative().describe('Count of staged files.'),
+    unstagedCount: z.number().int().nonnegative().describe('Count of unstaged files.'),
+    untrackedCount: z.number().int().nonnegative().describe('Count of untracked files.'),
+    stagedFiles: z.array(z.string()).describe('Staged files relative to repo root.'),
+    unstagedFiles: z.array(z.string()).describe('Unstaged files relative to repo root.'),
+    untrackedFiles: z.array(z.string()).describe('Untracked files relative to repo root.'),
+  })
+  .describe('Worktree dirty-state summary.')
+
+const GitContextSummarySchema = z
+  .object({
+    commitCountSinceBase: z.number().int().nonnegative().describe('Commit count since merge-base with base ref.'),
+    changedFileCountSinceBase: z.number().int().nonnegative().describe('Changed file count since merge-base.'),
+    deletedFileCountSinceBase: z.number().int().nonnegative().describe('Deleted file count since merge-base.'),
+    worktreeCount: z.number().int().nonnegative().describe('Number of detected worktrees when requested.'),
+  })
+  .describe('High-level Git context summary counts.')
+
+export const GitContextInputSchema = GitHistoryInputSchema.extend({
+  includeWorktrees: z
+    .boolean()
+    .default(false)
+    .describe('When true, include parsed worktree metadata in the assembled Git context output.'),
+})
+  .merge(GitWorktreesInputSchema)
+  .describe('Input contract for read-only local Git context assembly.')
+
+export const GitContextOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates Git context assembly completed successfully.'),
+    repoRoot: z.string().min(1).describe('Resolved repository root.'),
+    branch: z.string().nullable().describe('Current branch name, or null when detached.'),
+    head: z.string().min(1).describe('Current HEAD commit SHA.'),
+    upstream: z.string().nullable().describe('Current branch upstream ref when configured.'),
+    base: z.string().min(1).describe('Requested base ref used for comparison.'),
+    baseHead: z.string().nullable().describe('Resolved base ref SHA when available.'),
+    mergeBase: z.string().nullable().describe('Merge-base SHA between HEAD and base ref when available.'),
+    dirty: DirtySummarySchema.describe('Dirty-state summary for staged/unstaged/untracked changes.'),
+    commitsSinceBase: z.array(GitCommitSchema).describe('Recent commits from merge-base..HEAD.'),
+    changedFilesSinceBase: z.array(GitChangedFileSchema).describe('Changed files from merge-base...HEAD.'),
+    pathHistory: z
+      .array(GitPathHistoryEntrySchema)
+      .describe('Per-path recent commit history when paths were provided.'),
+    worktrees: z.array(GitWorktreeEntrySchema).describe('Parsed worktree metadata entries when requested.'),
+    summary: GitContextSummarySchema.describe('High-level Git context summary counts.'),
+    warnings: z
+      .array(z.string())
+      .describe('Warnings about dirty state, missing refs, broad changes, or stale worktrees.'),
+    suggestedNextCommands: z.array(z.string()).describe('Suggested follow-up Git inspection commands.'),
+  })
+  .describe('Output contract for read-only local Git context assembly.')
+
+export type GitContextInput = z.infer<typeof GitContextInputSchema>
+export type GitContextOutput = z.infer<typeof GitContextOutputSchema>
+
+const unique = (items: string[]): string[] => [...new Set(items)]
+
+export const assembleGitContext = async (input: GitContextInput): Promise<GitContextOutput> => {
+  const cwd = resolve(input.cwd ?? process.cwd())
+  const repoRoot = await resolveGitRepoRoot(cwd)
+  const base = input.base
+
+  const [branch, head, upstream, dirtyState, history] = await Promise.all([
+    resolveCurrentBranch({ cwd: repoRoot }),
+    resolveHead({ cwd: repoRoot }),
+    resolveUpstream({ cwd: repoRoot }),
+    collectDirtyState({ cwd: repoRoot }),
+    collectGitHistory({
+      cwd: repoRoot,
+      base: input.base,
+      paths: input.paths,
+      limit: input.limit,
+    }),
+  ])
+
+  const worktreeContext = input.includeWorktrees
+    ? await collectGitWorktrees({
+        cwd: repoRoot,
+      })
+    : null
+
+  const dirty = {
+    isDirty:
+      dirtyState.stagedFiles.length > 0 || dirtyState.unstagedFiles.length > 0 || dirtyState.untrackedFiles.length > 0,
+    stagedCount: dirtyState.stagedFiles.length,
+    unstagedCount: dirtyState.unstagedFiles.length,
+    untrackedCount: dirtyState.untrackedFiles.length,
+    stagedFiles: dirtyState.stagedFiles,
+    unstagedFiles: dirtyState.unstagedFiles,
+    untrackedFiles: dirtyState.untrackedFiles,
+  }
+
+  const warnings = [...history.warnings]
+  if (dirty.isDirty) {
+    warnings.push(
+      `Dirty worktree detected: ${dirty.stagedCount} staged, ${dirty.unstagedCount} unstaged, ${dirty.untrackedCount} untracked.`,
+    )
+  }
+  if (!upstream) {
+    warnings.push('Current branch has no configured upstream tracking ref.')
+  }
+
+  for (const worktreeWarning of worktreeContext?.warnings ?? []) {
+    warnings.push(worktreeWarning)
+  }
+
+  const deletedCount = history.summary.deletedFileCountSinceBase
+  if (deletedCount > 0) {
+    warnings.push(`Deleted files detected in branch changes: ${deletedCount}.`)
+  }
+
+  const suggestedNextCommands = unique([
+    'git status --short --branch',
+    'git log --oneline -20',
+    ...history.suggestedNextCommands,
+    ...(worktreeContext?.suggestedNextCommands ?? []),
+    `bun skills/plaited-context/scripts/git-history.ts '{"base":"${base}","paths":${JSON.stringify(history.paths)},"limit":${input.limit}}'`,
+  ])
+
+  return {
+    ok: true,
+    repoRoot,
+    branch,
+    head,
+    upstream,
+    base,
+    baseHead: history.baseHead,
+    mergeBase: history.mergeBase,
+    dirty,
+    commitsSinceBase: history.commitsSinceBase,
+    changedFilesSinceBase: history.changedFilesSinceBase,
+    pathHistory: history.pathHistory,
+    worktrees: worktreeContext?.worktrees ?? [],
+    summary: {
+      commitCountSinceBase: history.summary.commitCountSinceBase,
+      changedFileCountSinceBase: history.summary.changedFileCountSinceBase,
+      deletedFileCountSinceBase: deletedCount,
+      worktreeCount: worktreeContext?.worktrees.length ?? 0,
+    },
+    warnings: unique(warnings),
+    suggestedNextCommands,
+  }
+}
+
+export const gitContextCli = makeCli({
+  name: 'skills/plaited-context/scripts/git-context.ts',
+  inputSchema: GitContextInputSchema,
+  outputSchema: GitContextOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["skills/plaited-context"],"includeWorktrees":true}'`,
+    `  bun skills/plaited-context/scripts/git-context.ts --schema output`,
+  ].join('\n'),
+  run: assembleGitContext,
+})
+
+if (import.meta.main) {
+  try {
+    await gitContextCli(Bun.argv.slice(2))
+  } catch (error) {
+    console.error(JSON.stringify(buildStructuredCliError(error), null, 2))
+    process.exit(1)
+  }
+}

--- a/skills/plaited-context/scripts/git-context.ts
+++ b/skills/plaited-context/scripts/git-context.ts
@@ -4,6 +4,8 @@ import { makeCli } from '../../../src/cli.ts'
 import {
   buildStructuredCliError,
   collectDirtyState,
+  formatGitCommand,
+  formatShellCommand,
   GitChangedFileSchema,
   GitCommitSchema,
   GitPathHistoryEntrySchema,
@@ -130,12 +132,22 @@ export const assembleGitContext = async (input: GitContextInput): Promise<GitCon
     warnings.push(`Deleted files detected in branch changes: ${deletedCount}.`)
   }
 
+  const historySuggestionInput = {
+    base,
+    paths: history.paths,
+    limit: input.limit,
+  }
+
   const suggestedNextCommands = unique([
-    'git status --short --branch',
-    'git log --oneline -20',
+    formatGitCommand(['status', '--short', '--branch']),
+    formatGitCommand(['log', '--oneline', '-20']),
     ...history.suggestedNextCommands,
     ...(worktreeContext?.suggestedNextCommands ?? []),
-    `bun skills/plaited-context/scripts/git-history.ts '{"base":"${base}","paths":${JSON.stringify(history.paths)},"limit":${input.limit}}'`,
+    formatShellCommand([
+      'bun',
+      'skills/plaited-context/scripts/git-history.ts',
+      JSON.stringify(historySuggestionInput),
+    ]),
   ])
 
   return {

--- a/skills/plaited-context/scripts/git-history.ts
+++ b/skills/plaited-context/scripts/git-history.ts
@@ -6,6 +6,7 @@ import {
   collectChangedFiles,
   collectCommits,
   collectPathHistory,
+  formatGitCommand,
   GitChangedFileSchema,
   GitCommitSchema,
   GitPathHistoryEntrySchema,
@@ -84,18 +85,21 @@ const buildSuggestedCommands = ({
   paths: string[]
   limit: number
 }): string[] => {
-  const commands: string[] = [`git merge-base HEAD ${base}`, `git log --oneline -${limit}`]
+  const commands: string[] = [
+    formatGitCommand(['merge-base', 'HEAD', base]),
+    formatGitCommand(['log', '--oneline', `-${limit}`]),
+  ]
 
   if (mergeBase) {
-    commands.push(`git log --oneline -${limit} ${mergeBase}..HEAD`)
-    commands.push(`git diff --stat ${mergeBase}...HEAD`)
-    commands.push(`git diff --name-status ${mergeBase}...HEAD`)
+    commands.push(formatGitCommand(['log', '--oneline', `-${limit}`, `${mergeBase}..HEAD`]))
+    commands.push(formatGitCommand(['diff', '--stat', `${mergeBase}...HEAD`]))
+    commands.push(formatGitCommand(['diff', '--name-status', `${mergeBase}...HEAD`]))
   } else {
-    commands.push(`git rev-parse --verify ${base}^{commit}`)
+    commands.push(formatGitCommand(['rev-parse', '--verify', `${base}^{commit}`]))
   }
 
   for (const path of paths) {
-    commands.push(`git log --oneline -${limit} -- ${path}`)
+    commands.push(formatGitCommand(['log', '--oneline', `-${limit}`, '--', path]))
   }
 
   return unique(commands)

--- a/skills/plaited-context/scripts/git-history.ts
+++ b/skills/plaited-context/scripts/git-history.ts
@@ -1,0 +1,227 @@
+import { resolve } from 'node:path'
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  buildStructuredCliError,
+  collectChangedFiles,
+  collectCommits,
+  collectPathHistory,
+  GitChangedFileSchema,
+  GitCommitSchema,
+  GitPathHistoryEntrySchema,
+  resolveGitRef,
+  resolveGitRepoRoot,
+  resolveMergeBase,
+  resolvePathListWithinRepo,
+} from './git-context.shared.ts'
+
+const DEFAULT_LIMIT = 20
+const MAX_CHANGED_FILES = 200
+const BROAD_CHANGED_FILE_THRESHOLD = 80
+const BROAD_COMMIT_THRESHOLD = 40
+
+export const GitHistoryInputSchema = z
+  .object({
+    cwd: z.string().min(1).optional().describe('Optional working directory used for repository discovery.'),
+    base: z.string().min(1).default('origin/dev').describe('Base ref used to compute merge-base and branch delta.'),
+    paths: z.array(z.string().min(1)).default([]).describe('Optional paths to gather per-path recent commit history.'),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(200)
+      .default(DEFAULT_LIMIT)
+      .describe('Maximum commit history rows to return per query.'),
+  })
+  .describe('Input contract for read-only Git history context assembly.')
+
+const GitHistorySummarySchema = z
+  .object({
+    commitCountSinceBase: z.number().int().nonnegative().describe('Number of commits since merge-base with base ref.'),
+    changedFileCountSinceBase: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe('Number of changed files since merge-base with base ref.'),
+    deletedFileCountSinceBase: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe('Number of deleted files since merge-base with base ref.'),
+  })
+  .describe('High-level history summary counts.')
+
+export const GitHistoryOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates Git history context collection succeeded.'),
+    repoRoot: z.string().min(1).describe('Resolved repository root.'),
+    base: z.string().min(1).describe('Requested base ref.'),
+    baseHead: z.string().nullable().describe('Resolved base ref SHA when available.'),
+    mergeBase: z.string().nullable().describe('Merge-base SHA between HEAD and base ref when available.'),
+    paths: z.array(z.string()).describe('Validated repo-relative paths used for path history queries.'),
+    commitsSinceBase: z.array(GitCommitSchema).describe('Recent commits from merge-base..HEAD.'),
+    changedFilesSinceBase: z.array(GitChangedFileSchema).describe('Changed files from merge-base...HEAD.'),
+    pathHistory: z.array(GitPathHistoryEntrySchema).describe('Recent per-path commit history for requested paths.'),
+    summary: GitHistorySummarySchema.describe('High-level commit/file summary.'),
+    warnings: z.array(z.string()).describe('Warnings about missing refs, broad changes, or deleted files.'),
+    suggestedNextCommands: z.array(z.string()).describe('Suggested follow-up Git inspection commands.'),
+  })
+  .describe('Output contract for read-only Git history context assembly.')
+
+export type GitHistoryInput = z.infer<typeof GitHistoryInputSchema>
+export type GitHistoryOutput = z.infer<typeof GitHistoryOutputSchema>
+
+const unique = (items: string[]): string[] => [...new Set(items)]
+
+const buildSuggestedCommands = ({
+  base,
+  mergeBase,
+  paths,
+  limit,
+}: {
+  base: string
+  mergeBase: string | null
+  paths: string[]
+  limit: number
+}): string[] => {
+  const commands: string[] = [`git merge-base HEAD ${base}`, `git log --oneline -${limit}`]
+
+  if (mergeBase) {
+    commands.push(`git log --oneline -${limit} ${mergeBase}..HEAD`)
+    commands.push(`git diff --stat ${mergeBase}...HEAD`)
+    commands.push(`git diff --name-status ${mergeBase}...HEAD`)
+  } else {
+    commands.push(`git rev-parse --verify ${base}^{commit}`)
+  }
+
+  for (const path of paths) {
+    commands.push(`git log --oneline -${limit} -- ${path}`)
+  }
+
+  return unique(commands)
+}
+
+export const collectGitHistory = async (input: GitHistoryInput): Promise<GitHistoryOutput> => {
+  const cwd = resolve(input.cwd ?? process.cwd())
+  const repoRoot = await resolveGitRepoRoot(cwd)
+  const base = input.base
+  const limit = input.limit
+  const validatedPaths = resolvePathListWithinRepo({
+    repoRoot,
+    paths: input.paths,
+  })
+  const warnings: string[] = []
+
+  const baseHead = await resolveGitRef({
+    cwd: repoRoot,
+    ref: base,
+  })
+  if (!baseHead) {
+    warnings.push(`Base ref '${base}' could not be resolved in this repository.`)
+  }
+
+  const mergeBase = baseHead
+    ? await resolveMergeBase({
+        cwd: repoRoot,
+        baseRef: base,
+      })
+    : null
+
+  if (baseHead && !mergeBase) {
+    warnings.push(`Merge-base between HEAD and '${base}' could not be resolved.`)
+  }
+
+  const commitsSinceBase = mergeBase
+    ? await collectCommits({
+        cwd: repoRoot,
+        range: `${mergeBase}..HEAD`,
+        limit,
+      })
+    : []
+
+  const changedFilesSinceBaseRaw = mergeBase
+    ? await collectChangedFiles({
+        cwd: repoRoot,
+        mergeBase,
+      })
+    : []
+
+  const changedFilesSinceBase = changedFilesSinceBaseRaw.slice(0, MAX_CHANGED_FILES)
+  if (changedFilesSinceBaseRaw.length > MAX_CHANGED_FILES) {
+    warnings.push(`Changed file list was truncated to ${MAX_CHANGED_FILES} entries to keep output focused.`)
+  }
+
+  const pathHistory = await collectPathHistory({
+    cwd: repoRoot,
+    paths: validatedPaths,
+    limit,
+  })
+
+  const deletedFileCountSinceBase = changedFilesSinceBaseRaw.filter((entry) => entry.status === 'D').length
+  if (deletedFileCountSinceBase > 0) {
+    warnings.push(`Branch includes ${deletedFileCountSinceBase} deleted file change(s) since merge-base.`)
+  }
+
+  if (changedFilesSinceBaseRaw.length > BROAD_CHANGED_FILE_THRESHOLD) {
+    warnings.push(
+      `Broad change surface: ${changedFilesSinceBaseRaw.length} changed files since merge-base (${BROAD_CHANGED_FILE_THRESHOLD}+).`,
+    )
+  }
+
+  if (commitsSinceBase.length > BROAD_COMMIT_THRESHOLD) {
+    warnings.push(
+      `Broad commit range: ${commitsSinceBase.length} commits since merge-base (${BROAD_COMMIT_THRESHOLD}+).`,
+    )
+  }
+
+  if (baseHead && mergeBase && baseHead !== mergeBase) {
+    warnings.push(
+      `Current branch merge-base (${mergeBase.slice(0, 12)}) differs from ${base} head (${baseHead.slice(0, 12)}).`,
+    )
+  }
+
+  return {
+    ok: true,
+    repoRoot,
+    base,
+    baseHead,
+    mergeBase,
+    paths: validatedPaths,
+    commitsSinceBase,
+    changedFilesSinceBase,
+    pathHistory,
+    summary: {
+      commitCountSinceBase: commitsSinceBase.length,
+      changedFileCountSinceBase: changedFilesSinceBaseRaw.length,
+      deletedFileCountSinceBase,
+    },
+    warnings,
+    suggestedNextCommands: buildSuggestedCommands({
+      base,
+      mergeBase,
+      paths: validatedPaths,
+      limit,
+    }),
+  }
+}
+
+export const gitHistoryCli = makeCli({
+  name: 'skills/plaited-context/scripts/git-history.ts',
+  inputSchema: GitHistoryInputSchema,
+  outputSchema: GitHistoryOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/git-history.ts '{"base":"origin/dev","paths":["src/modules"],"limit":20}'`,
+    `  bun skills/plaited-context/scripts/git-history.ts --schema output`,
+  ].join('\n'),
+  run: collectGitHistory,
+})
+
+if (import.meta.main) {
+  try {
+    await gitHistoryCli(Bun.argv.slice(2))
+  } catch (error) {
+    console.error(JSON.stringify(buildStructuredCliError(error), null, 2))
+    process.exit(1)
+  }
+}

--- a/skills/plaited-context/scripts/git-worktrees.ts
+++ b/skills/plaited-context/scripts/git-worktrees.ts
@@ -1,0 +1,86 @@
+import { resolve } from 'node:path'
+import * as z from 'zod'
+import { makeCli } from '../../../src/cli.ts'
+import {
+  buildStructuredCliError,
+  collectWorktrees,
+  GitWorktreeEntrySchema,
+  resolveGitRepoRoot,
+} from './git-context.shared.ts'
+
+export const GitWorktreesInputSchema = z
+  .object({
+    cwd: z.string().min(1).optional().describe('Optional working directory used for repository discovery.'),
+  })
+  .describe('Input contract for read-only Git worktree metadata collection.')
+
+export const GitWorktreesOutputSchema = z
+  .object({
+    ok: z.literal(true).describe('Indicates Git worktree metadata collection succeeded.'),
+    repoRoot: z.string().min(1).describe('Resolved repository root.'),
+    currentWorktree: z.string().min(1).describe('Absolute path for the current worktree root.'),
+    worktrees: z.array(GitWorktreeEntrySchema).describe('Parsed worktree metadata entries.'),
+    warnings: z.array(z.string()).describe('Warnings for prunable/missing worktrees that may be stale.'),
+    suggestedNextCommands: z.array(z.string()).describe('Suggested follow-up Git worktree inspection commands.'),
+  })
+  .describe('Output contract for read-only Git worktree metadata collection.')
+
+export type GitWorktreesInput = z.infer<typeof GitWorktreesInputSchema>
+export type GitWorktreesOutput = z.infer<typeof GitWorktreesOutputSchema>
+
+const unique = (items: string[]): string[] => [...new Set(items)]
+
+export const collectGitWorktrees = async (input: GitWorktreesInput): Promise<GitWorktreesOutput> => {
+  const cwd = resolve(input.cwd ?? process.cwd())
+  const repoRoot = await resolveGitRepoRoot(cwd)
+  const worktrees = await collectWorktrees({
+    cwd: repoRoot,
+    currentWorktree: repoRoot,
+  })
+
+  const warnings: string[] = []
+  for (const worktree of worktrees) {
+    if (!worktree.exists) {
+      warnings.push(`Worktree path is missing on disk: ${worktree.path}`)
+    }
+    if (worktree.prunableReason !== null) {
+      warnings.push(`Worktree may be stale or prunable: ${worktree.path}`)
+    }
+  }
+
+  const suggestedNextCommands = unique([
+    'git worktree list --porcelain',
+    'git branch --all --verbose',
+    'git status --short --branch',
+  ])
+
+  return {
+    ok: true,
+    repoRoot,
+    currentWorktree: repoRoot,
+    worktrees,
+    warnings,
+    suggestedNextCommands,
+  }
+}
+
+export const gitWorktreesCli = makeCli({
+  name: 'skills/plaited-context/scripts/git-worktrees.ts',
+  inputSchema: GitWorktreesInputSchema,
+  outputSchema: GitWorktreesOutputSchema,
+  help: [
+    'Examples:',
+    `  bun skills/plaited-context/scripts/git-worktrees.ts '{}'`,
+    `  bun skills/plaited-context/scripts/git-worktrees.ts --schema output`,
+  ].join('\n'),
+  run: collectGitWorktrees,
+})
+
+if (import.meta.main) {
+  try {
+    await gitWorktreesCli(Bun.argv.slice(2))
+  } catch (error) {
+    console.error(JSON.stringify(buildStructuredCliError(error), null, 2))
+    process.exit(1)
+  }
+}

--- a/skills/plaited-context/scripts/plaited-context.ts
+++ b/skills/plaited-context/scripts/plaited-context.ts
@@ -1421,6 +1421,7 @@ export const assembleContext = ({
 
   const commandsToRun = isModuleActorReview
     ? [
+        `bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["<module-files>"],"includeWorktrees":true}'`,
         'bun --bun tsc --noEmit',
         'bun test <targeted-files-or-surface>',
         `bun skills/plaited-context/scripts/module-patterns.ts '{"files":["<module-files>"]}'`,
@@ -1431,17 +1432,28 @@ export const assembleContext = ({
         `bun skills/typescript-lsp/scripts/run.ts '{"file":"<module-file>","operations":[{"type":"definition","line":<line>,"character":<character>}]}'`,
       ]
     : mode === 'review'
-      ? ['bun --bun tsc --noEmit', 'bun test <targeted-files-or-surface>']
-      : mode === 'docs'
+      ? [
+          `bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["<paths>"]}'`,
+          'bun --bun tsc --noEmit',
+          'bun test <targeted-files-or-surface>',
+        ]
+      : mode === 'implement'
         ? [
-            `bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","docs","skills"]}'`,
-            `bun skills/plaited-context/scripts/wiki-context.ts '{"task":"<docs-task>","paths":["docs"],"limit":10}'`,
-          ]
-        : [
+            `bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["<paths>"]}'`,
             'bun --bun tsc --noEmit',
             'bun test <targeted-files-or-surface>',
             'bun skills/plaited-context/scripts/search.ts',
           ]
+        : mode === 'docs'
+          ? [
+              `bun skills/plaited-context/scripts/scan.ts '{"rootDir":".","include":["AGENTS.md","docs","skills"]}'`,
+              `bun skills/plaited-context/scripts/wiki-context.ts '{"task":"<docs-task>","paths":["docs"],"limit":10}'`,
+            ]
+          : [
+              'bun --bun tsc --noEmit',
+              'bun test <targeted-files-or-surface>',
+              'bun skills/plaited-context/scripts/search.ts',
+            ]
 
   const sourceOfTruth = unique([
     'src/ (code)',

--- a/skills/plaited-context/scripts/tests/git-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/git-context.spec.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { assembleGitContext } from '../git-context.ts'
+import { collectGitHistory } from '../git-history.ts'
+import { collectGitWorktrees } from '../git-worktrees.ts'
+
+const tempDirs: string[] = []
+
+const trackTempDir = (path: string): string => {
+  tempDirs.push(path)
+  return path
+}
+
+const runGit = async ({
+  cwd,
+  args,
+}: {
+  cwd: string
+  args: string[]
+}): Promise<{
+  stdout: string
+  stderr: string
+}> => {
+  const result = await Bun.$`git ${args}`.cwd(cwd).quiet().nothrow()
+  const stdout = result.stdout.toString().trim()
+  const stderr = result.stderr.toString().trim()
+
+  if (result.exitCode !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${stderr || stdout || `exit ${result.exitCode}`}`)
+  }
+
+  return {
+    stdout,
+    stderr,
+  }
+}
+
+const writeFile = async ({ cwd, path, content }: { cwd: string; path: string; content: string }) => {
+  const absolutePath = join(cwd, path)
+  await mkdir(dirname(absolutePath), { recursive: true })
+  await Bun.write(absolutePath, content)
+}
+
+const createTempGitRepo = async () => {
+  const rootDir = trackTempDir(await mkdtemp(join(tmpdir(), 'plaited-context-git-')))
+  await runGit({ cwd: rootDir, args: ['init'] })
+  await runGit({ cwd: rootDir, args: ['config', 'user.email', 'plaited-context@example.com'] })
+  await runGit({ cwd: rootDir, args: ['config', 'user.name', 'Plaited Context Test'] })
+  await runGit({ cwd: rootDir, args: ['checkout', '-b', 'dev'] })
+  await writeFile({
+    cwd: rootDir,
+    path: 'README.md',
+    content: '# temp git context repo\n',
+  })
+  await runGit({ cwd: rootDir, args: ['add', '.'] })
+  await runGit({ cwd: rootDir, args: ['commit', '-m', 'chore: create baseline commit'] })
+
+  await runGit({ cwd: rootDir, args: ['checkout', '-b', 'feature/git-context'] })
+
+  await writeFile({
+    cwd: rootDir,
+    path: 'src/app.ts',
+    content: `export const app = 'v1'\n`,
+  })
+  await runGit({ cwd: rootDir, args: ['add', 'src/app.ts'] })
+  await runGit({ cwd: rootDir, args: ['commit', '-m', 'feat: create app baseline'] })
+
+  await writeFile({
+    cwd: rootDir,
+    path: 'src/app.ts',
+    content: `export const app = 'v2'\n`,
+  })
+  await runGit({ cwd: rootDir, args: ['add', 'src/app.ts'] })
+  await runGit({ cwd: rootDir, args: ['commit', '-m', 'feat: update app implementation'] })
+
+  await writeFile({
+    cwd: rootDir,
+    path: 'docs/feature.md',
+    content: `# Feature Notes\n\nGit context integration notes.\n`,
+  })
+  await runGit({ cwd: rootDir, args: ['add', 'docs/feature.md'] })
+  await runGit({ cwd: rootDir, args: ['commit', '-m', 'docs: add feature notes'] })
+
+  return rootDir
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const directory = tempDirs.pop()
+    if (!directory) {
+      continue
+    }
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+describe('git-context scripts', () => {
+  test('returns clean output and warning when requested base ref is missing', async () => {
+    const rootDir = await createTempGitRepo()
+    const canonicalRootDir = await realpath(rootDir)
+
+    const output = await assembleGitContext({
+      cwd: rootDir,
+      base: 'origin/dev',
+      paths: ['src'],
+      limit: 20,
+      includeWorktrees: false,
+    })
+
+    expect(output.ok).toBe(true)
+    expect(output.repoRoot).toBe(canonicalRootDir)
+    expect(output.base).toBe('origin/dev')
+    expect(output.baseHead).toBeNull()
+    expect(output.mergeBase).toBeNull()
+    expect(output.dirty.isDirty).toBe(false)
+    expect(output.warnings.some((warning) => warning.includes("Base ref 'origin/dev' could not be resolved"))).toBe(
+      true,
+    )
+  })
+
+  test('returns dirty summary with staged, unstaged, and untracked counts', async () => {
+    const rootDir = await createTempGitRepo()
+
+    await writeFile({
+      cwd: rootDir,
+      path: 'src/app.ts',
+      content: `export const app = 'dirty-change'\n`,
+    })
+    await writeFile({
+      cwd: rootDir,
+      path: 'src/staged.ts',
+      content: `export const staged = true\n`,
+    })
+    await runGit({ cwd: rootDir, args: ['add', 'src/staged.ts'] })
+    await writeFile({
+      cwd: rootDir,
+      path: 'tmp-untracked.txt',
+      content: 'untracked\n',
+    })
+
+    const output = await assembleGitContext({
+      cwd: rootDir,
+      base: 'dev',
+      paths: ['src'],
+      limit: 20,
+      includeWorktrees: false,
+    })
+
+    expect(output.dirty.isDirty).toBe(true)
+    expect(output.dirty.stagedCount).toBeGreaterThan(0)
+    expect(output.dirty.unstagedCount).toBeGreaterThan(0)
+    expect(output.dirty.untrackedCount).toBeGreaterThan(0)
+    expect(output.warnings.some((warning) => warning.includes('Dirty worktree detected'))).toBe(true)
+  })
+
+  test('returns commits and changed files since local base', async () => {
+    const rootDir = await createTempGitRepo()
+
+    const output = await collectGitHistory({
+      cwd: rootDir,
+      base: 'dev',
+      paths: ['src/app.ts'],
+      limit: 20,
+    })
+
+    expect(output.ok).toBe(true)
+    expect(output.base).toBe('dev')
+    expect(output.baseHead).not.toBeNull()
+    expect(output.mergeBase).not.toBeNull()
+    expect(output.commitsSinceBase.length).toBeGreaterThanOrEqual(2)
+    expect(output.changedFilesSinceBase.some((entry) => entry.path === 'src/app.ts')).toBe(true)
+    expect(output.changedFilesSinceBase.some((entry) => entry.path === 'docs/feature.md')).toBe(true)
+    expect(output.summary.commitCountSinceBase).toBe(output.commitsSinceBase.length)
+    expect(output.summary.changedFileCountSinceBase).toBeGreaterThanOrEqual(2)
+  })
+
+  test('returns per-path history when paths are provided', async () => {
+    const rootDir = await createTempGitRepo()
+
+    const output = await collectGitHistory({
+      cwd: rootDir,
+      base: 'dev',
+      paths: ['src/app.ts', 'docs/feature.md'],
+      limit: 20,
+    })
+
+    expect(output.pathHistory).toHaveLength(2)
+    const appHistory = output.pathHistory.find((entry) => entry.path === 'src/app.ts')
+    const docsHistory = output.pathHistory.find((entry) => entry.path === 'docs/feature.md')
+    expect(appHistory?.commits.length).toBeGreaterThanOrEqual(2)
+    expect(docsHistory?.commits.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('parses worktree metadata when additional worktrees exist', async () => {
+    const rootDir = await createTempGitRepo()
+    const worktreeParent = trackTempDir(await mkdtemp(join(tmpdir(), 'plaited-context-worktree-parent-')))
+    const secondaryWorktree = join(worktreeParent, 'secondary')
+
+    await runGit({
+      cwd: rootDir,
+      args: ['worktree', 'add', '-b', 'feature/worktree-copy', secondaryWorktree, 'dev'],
+    })
+    const canonicalRootDir = await realpath(rootDir)
+    const canonicalSecondaryWorktree = await realpath(secondaryWorktree)
+
+    const output = await collectGitWorktrees({
+      cwd: rootDir,
+    })
+
+    expect(output.ok).toBe(true)
+    expect(output.worktrees.length).toBeGreaterThanOrEqual(2)
+    expect(output.worktrees.some((entry) => entry.path === canonicalRootDir && entry.isCurrent)).toBe(true)
+    expect(output.worktrees.some((entry) => entry.path === canonicalSecondaryWorktree)).toBe(true)
+  })
+
+  test('rejects paths that escape repository root', async () => {
+    const rootDir = await createTempGitRepo()
+
+    await expect(
+      collectGitHistory({
+        cwd: rootDir,
+        base: 'dev',
+        paths: ['../escape.ts'],
+        limit: 20,
+      }),
+    ).rejects.toThrow("Invalid path '../escape.ts': path escapes repository root.")
+  })
+
+  test('supports schema introspection for git scripts', async () => {
+    const gitContextInputSchemaText = (
+      await Bun.$`bun skills/plaited-context/scripts/git-context.ts --schema input`.cwd(process.cwd()).quiet()
+    ).stdout.toString()
+    const gitContextOutputSchemaText = (
+      await Bun.$`bun skills/plaited-context/scripts/git-context.ts --schema output`.cwd(process.cwd()).quiet()
+    ).stdout.toString()
+    const gitHistoryOutputSchemaText = (
+      await Bun.$`bun skills/plaited-context/scripts/git-history.ts --schema output`.cwd(process.cwd()).quiet()
+    ).stdout.toString()
+    const gitWorktreesOutputSchemaText = (
+      await Bun.$`bun skills/plaited-context/scripts/git-worktrees.ts --schema output`.cwd(process.cwd()).quiet()
+    ).stdout.toString()
+
+    const gitContextInputSchema = JSON.parse(gitContextInputSchemaText) as {
+      properties?: Record<string, unknown>
+    }
+    const gitContextOutputSchema = JSON.parse(gitContextOutputSchemaText) as {
+      properties?: Record<string, unknown>
+    }
+    const gitHistoryOutputSchema = JSON.parse(gitHistoryOutputSchemaText) as {
+      properties?: Record<string, unknown>
+    }
+    const gitWorktreesOutputSchema = JSON.parse(gitWorktreesOutputSchemaText) as {
+      properties?: Record<string, unknown>
+    }
+
+    expect(gitContextInputSchema.properties?.base).toBeDefined()
+    expect(gitContextInputSchema.properties?.includeWorktrees).toBeDefined()
+    expect(gitContextOutputSchema.properties?.dirty).toBeDefined()
+    expect(gitContextOutputSchema.properties?.commitsSinceBase).toBeDefined()
+    expect(gitHistoryOutputSchema.properties?.changedFilesSinceBase).toBeDefined()
+    expect(gitWorktreesOutputSchema.properties?.worktrees).toBeDefined()
+  })
+})

--- a/skills/plaited-context/scripts/tests/git-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/git-context.spec.ts
@@ -229,6 +229,76 @@ describe('git-context scripts', () => {
     ).rejects.toThrow("Invalid path '../escape.ts': path escapes repository root.")
   })
 
+  test('quotes shell metacharacters in base ref suggested commands', async () => {
+    const rootDir = await createTempGitRepo()
+    const injectedBase = 'origin/dev; echo injected'
+
+    const output = await collectGitHistory({
+      cwd: rootDir,
+      base: injectedBase,
+      paths: [],
+      limit: 1,
+    })
+
+    const mergeBaseSuggestion = output.suggestedNextCommands.find((command) => command.startsWith('git merge-base '))
+    const revParseSuggestion = output.suggestedNextCommands.find((command) => command.startsWith('git rev-parse '))
+
+    expect(mergeBaseSuggestion).toBe("git merge-base HEAD 'origin/dev; echo injected'")
+    expect(mergeBaseSuggestion?.includes('HEAD origin/dev; echo injected')).toBe(false)
+    expect(revParseSuggestion).toBe("git rev-parse --verify 'origin/dev; echo injected^{commit}'")
+    expect(revParseSuggestion?.includes('--verify origin/dev; echo injected^{commit}')).toBe(false)
+  })
+
+  test('quotes path suggestions with spaces in git log command', async () => {
+    const rootDir = await createTempGitRepo()
+    const pathWithSpaces = 'docs/path with space.md'
+
+    const output = await collectGitHistory({
+      cwd: rootDir,
+      base: 'dev',
+      paths: [pathWithSpaces],
+      limit: 1,
+    })
+
+    expect(output.suggestedNextCommands).toContain("git log --oneline -1 -- 'docs/path with space.md'")
+  })
+
+  test('renders git-context git-history suggestion with one quoted JSON argument', async () => {
+    const rootDir = await createTempGitRepo()
+    const base = 'origin/dev; echo injected'
+    const paths = ['docs/path with space.md']
+
+    const output = await assembleGitContext({
+      cwd: rootDir,
+      base,
+      paths,
+      limit: 1,
+      includeWorktrees: false,
+    })
+
+    const historySuggestion = output.suggestedNextCommands.find((command) =>
+      command.startsWith('bun skills/plaited-context/scripts/git-history.ts '),
+    )
+    expect(historySuggestion).toBeDefined()
+
+    const quotedJsonMatch = historySuggestion?.match(
+      /^bun skills\/plaited-context\/scripts\/git-history\.ts ('[^']+')$/,
+    )
+    expect(quotedJsonMatch).toBeDefined()
+
+    const jsonPayload = quotedJsonMatch?.[1]?.slice(1, -1)
+    expect(jsonPayload).toBeDefined()
+
+    const parsedPayload = JSON.parse(jsonPayload ?? '{}') as {
+      base?: string
+      paths?: string[]
+      limit?: number
+    }
+    expect(parsedPayload.base).toBe(base)
+    expect(parsedPayload.paths).toEqual(paths)
+    expect(parsedPayload.limit).toBe(1)
+  })
+
   test('supports schema introspection for git scripts', async () => {
     const gitContextInputSchemaText = (
       await Bun.$`bun skills/plaited-context/scripts/git-context.ts --schema input`.cwd(process.cwd()).quiet()

--- a/skills/plaited-context/scripts/tests/plaited-context.spec.ts
+++ b/skills/plaited-context/scripts/tests/plaited-context.spec.ts
@@ -193,6 +193,9 @@ describe('plaited-context scripts', () => {
 
     expect(contextOutput.ok).toBe(true)
     expect(contextOutput.filesToRead).toContain('src/example.ts')
+    expect(
+      contextOutput.commandsToRun.some((command) => command.includes('skills/plaited-context/scripts/git-context.ts')),
+    ).toBe(true)
 
     const findingOutput = await recordFindingEntry({
       cwd: rootDir,
@@ -447,6 +450,9 @@ describe('plaited-context scripts', () => {
     expect(contextOutput.commandsToRun).toContain('bun --bun tsc --noEmit')
     expect(contextOutput.commandsToRun).toContain('bun test <targeted-files-or-surface>')
     expect(
+      contextOutput.commandsToRun.some((command) => command.includes('skills/plaited-context/scripts/git-context.ts')),
+    ).toBe(true)
+    expect(
       contextOutput.commandsToRun.some((command) =>
         command.includes('skills/plaited-context/scripts/module-patterns.ts'),
       ),
@@ -501,5 +507,39 @@ describe('plaited-context scripts', () => {
       'other',
     ])
     expect(contextOutput.authorityPolicy).toContain('outrank')
+  })
+
+  test('context recommends git-context command for implementation mode', async () => {
+    const rootDir = await createTempWorkspace()
+    const dbPath = join(rootDir, '.plaited/context.sqlite')
+
+    await initDb({
+      cwd: rootDir,
+      dbPath,
+    })
+
+    await scanWorkspace({
+      cwd: rootDir,
+      rootDir,
+      dbPath,
+      include: ['AGENTS.md', 'src', 'skills', 'docs'],
+      force: true,
+    })
+
+    const contextOutput = await assembleTaskContext({
+      cwd: rootDir,
+      dbPath,
+      task: 'implement git context output formatter',
+      mode: 'implement',
+      paths: ['skills/plaited-context'],
+    })
+
+    expect(contextOutput.ok).toBe(true)
+    expect(
+      contextOutput.commandsToRun.some((command) => command.includes('skills/plaited-context/scripts/git-context.ts')),
+    ).toBe(true)
+    expect(contextOutput.commandsToRun).toContain('bun --bun tsc --noEmit')
+    expect(contextOutput.commandsToRun).toContain('bun test <targeted-files-or-surface>')
+    expect(contextOutput.commandsToRun).toContain('bun skills/plaited-context/scripts/search.ts')
   })
 })


### PR DESCRIPTION
## Context

- Fixes #322
- Slice 4 adds local read-only Git context assembly to plaited-context so review/implementation workflows can include branch/worktree/history evidence from the current repo state.

## Summary

- Added read-only Git scripts under `skills/plaited-context/scripts/`:
  - `git-context.ts` (top-level branch/head/base/dirty/history/worktree context)
  - `git-history.ts` (merge-base, commits/files since base, path history)
  - `git-worktrees.ts` (worktree porcelain parsing and stale/prunable warnings)
  - `git-context.shared.ts` (shared parsing, safe path validation, read-only git runner, structured git command errors)
- Updated `assembleContext` command recommendations to include `git-context.ts` for `review` and `implement` modes and alongside existing module actor review baseline/module-analysis commands.
- Updated skill guidance:
  - `skills/plaited-context/SKILL.md` with read-only Git context scope and non-authorization boundaries.
  - `.agents/skills/plaited-development/SKILL.md` with dedicated-worktree commit handoff guidance.
- Added focused tests using temporary Git repos for clean/dirty/history/path/worktree/schema coverage and command-list integration coverage.

## Changed Files

- `.agents/skills/plaited-development/SKILL.md`
- `skills/plaited-context/SKILL.md`
- `skills/plaited-context/scripts/plaited-context.ts`
- `skills/plaited-context/scripts/git-context.shared.ts`
- `skills/plaited-context/scripts/git-context.ts`
- `skills/plaited-context/scripts/git-history.ts`
- `skills/plaited-context/scripts/git-worktrees.ts`
- `skills/plaited-context/scripts/tests/plaited-context.spec.ts`
- `skills/plaited-context/scripts/tests/git-context.spec.ts`

## Validation

- Targeted tests:
  - `bun test skills/plaited-context/scripts/tests`
  - `bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["skills/plaited-context"],"includeWorktrees":true}'`
  - `bun skills/plaited-context/scripts/git-context.ts --schema input`
  - `bun skills/plaited-context/scripts/git-context.ts --schema output`
  - `bun skills/plaited-context/scripts/git-history.ts '{"base":"origin/dev","paths":["skills/plaited-context"],"limit":20}'`
  - `bun skills/plaited-context/scripts/git-history.ts --schema input`
  - `bun skills/plaited-context/scripts/git-history.ts --schema output`
  - `bun skills/plaited-context/scripts/git-worktrees.ts '{}'`
  - `bun skills/plaited-context/scripts/git-worktrees.ts --schema input`
  - `bun skills/plaited-context/scripts/git-worktrees.ts --schema output`
  - `bun skills/plaited-context/scripts/context.ts '{"task":"review plaited-context git layer","mode":"review","paths":["skills/plaited-context"]}'`
  - `bun bin/plaited.ts skills-validate '{"skillPath":"skills/plaited-context/SKILL.md"}'`
  - `bun bin/plaited.ts skills-links '{"rootDir":".","path":"skills/plaited-context"}'`
  - `bun bin/plaited.ts skills-validate '{"skillPath":".agents/skills/plaited-development/SKILL.md"}'`
- `bun --bun tsc --noEmit`: pass

## Known Failures / Drift

- None observed in this slice.

## Review Notes / Residual Risks

- Worktree warning coverage depends on `git worktree list --porcelain` metadata (missing/prunable flags). It does not infer stale state beyond those signals.
- Path parsing follows porcelain text output and may not fully decode every edge-case quoted filename format.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
