### PR TITLE
feat(modules): add projection boundary actor for MSS slice 6

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,3 +1,4 @@
 export * from './modules/execution-process-actor.ts'
 export * from './modules/inference-websocket-runtime-actor.ts'
+export * from './modules/projection-boundary-actor.ts'
 export * from './modules/ui-websocket-runtime-actor.ts'

--- a/src/modules/projection-boundary-actor.ts
+++ b/src/modules/projection-boundary-actor.ts
@@ -1,0 +1,347 @@
+import * as z from 'zod'
+import { useExtension } from '../behavioral.ts'
+import { keyMirror } from '../utils.ts'
+
+export const PROJECTION_BOUNDARY_ACTOR_ID = 'projection_boundary_actor'
+
+export const PROJECTION_BOUNDARY_ACTOR_EVENTS = keyMirror(
+  'projection_descriptor_register',
+  'projection_descriptor_registered',
+  'projection_request_evaluate',
+  'projection_decision',
+)
+
+export const toProjectionBoundaryActorEventType = <TEvent extends string>(
+  event: TEvent,
+): `${typeof PROJECTION_BOUNDARY_ACTOR_ID}:${TEvent}` => `${PROJECTION_BOUNDARY_ACTOR_ID}:${event}`
+
+export const ModuleSharingPolicySchema = z.enum(['all', 'none', 'ask'])
+export type ModuleSharingPolicy = z.infer<typeof ModuleSharingPolicySchema>
+
+export const ProjectionDecisionSchema = z.enum(['allow', 'deny', 'ask'])
+export type ProjectionDecision = z.infer<typeof ProjectionDecisionSchema>
+
+export const ProjectionAudienceSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    kind: z.string().min(1),
+  })
+  .passthrough()
+export type ProjectionAudience = z.infer<typeof ProjectionAudienceSchema>
+
+export const ProjectionShapeSchema = z.object({
+  fields: z.array(z.string().min(1)).default([]),
+  facts: z.array(z.string().min(1)).default([]),
+  resources: z.array(z.string().min(1)).default([]),
+})
+export type ProjectionShape = z.infer<typeof ProjectionShapeSchema>
+
+export const RequestedProjectionShapeSchema = z.object({
+  fields: z.array(z.string().min(1)).optional(),
+  facts: z.array(z.string().min(1)).optional(),
+  resources: z.array(z.string().min(1)).optional(),
+})
+export type RequestedProjectionShape = z.infer<typeof RequestedProjectionShapeSchema>
+
+export const ProjectionScopeSchema = z.record(z.string(), z.unknown())
+export type ProjectionScope = z.infer<typeof ProjectionScopeSchema>
+
+export const ProjectionProvenanceSchema = z
+  .object({
+    sourceId: z.string().min(1).optional(),
+    sourceModuleId: z.string().min(1).optional(),
+    lineage: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough()
+export type ProjectionProvenance = z.infer<typeof ProjectionProvenanceSchema>
+
+export const ProjectionDescriptorSchema = z.object({
+  projectionId: z.string().min(1),
+  sourceModuleId: z.string().min(1),
+  audience: ProjectionAudienceSchema,
+  shape: ProjectionShapeSchema,
+  scope: ProjectionScopeSchema.optional(),
+  provenance: ProjectionProvenanceSchema.optional(),
+})
+export type ProjectionDescriptor = z.infer<typeof ProjectionDescriptorSchema>
+
+export const ProjectionDescriptorRegistrationSchema = z.object({
+  descriptor: ProjectionDescriptorSchema,
+})
+export type ProjectionDescriptorRegistration = z.infer<typeof ProjectionDescriptorRegistrationSchema>
+
+export const ProjectionRequestSchema = z.object({
+  requestId: z.string().min(1),
+  correlationId: z.string().min(1),
+  sourceModuleId: z.string().min(1),
+  projectionId: z.string().min(1),
+  requester: ProjectionAudienceSchema,
+  moduleSharingPolicy: ModuleSharingPolicySchema,
+  requestedShape: RequestedProjectionShapeSchema.optional(),
+  scope: ProjectionScopeSchema.optional(),
+  provenance: ProjectionProvenanceSchema.optional(),
+})
+export type ProjectionRequest = z.infer<typeof ProjectionRequestSchema>
+
+export const ProjectionRequirementSchema = z
+  .object({
+    kind: z.string().min(1),
+  })
+  .passthrough()
+export type ProjectionRequirement = z.infer<typeof ProjectionRequirementSchema>
+
+export const ProjectionDecisionDetailSchema = z.object({
+  requestId: z.string().min(1),
+  correlationId: z.string().min(1),
+  sourceModuleId: z.string().min(1),
+  projectionId: z.string().min(1),
+  decision: ProjectionDecisionSchema,
+  reason: z.string().min(1),
+  requirements: z.array(ProjectionRequirementSchema),
+  approvedShape: ProjectionShapeSchema.optional(),
+  audience: ProjectionAudienceSchema.optional(),
+  requestProvenance: ProjectionProvenanceSchema.optional(),
+  descriptorProvenance: ProjectionProvenanceSchema.optional(),
+})
+export type ProjectionDecisionDetail = z.infer<typeof ProjectionDecisionDetailSchema>
+
+type EvaluateProjectionRequestParams = {
+  request: ProjectionRequest
+  descriptorLookup: ReadonlyMap<string, ProjectionDescriptor>
+}
+
+const isAudienceMatch = ({
+  descriptorAudience,
+  requesterAudience,
+}: {
+  descriptorAudience: ProjectionAudience
+  requesterAudience: ProjectionAudience
+}) => {
+  if (descriptorAudience.kind !== requesterAudience.kind) {
+    return false
+  }
+
+  if (descriptorAudience.id === undefined) {
+    return true
+  }
+
+  return descriptorAudience.id === requesterAudience.id
+}
+
+const isRequestedShapeWithinDescriptor = ({
+  requestedShape,
+  descriptorShape,
+}: {
+  requestedShape: RequestedProjectionShape | undefined
+  descriptorShape: ProjectionShape
+}) => {
+  if (!requestedShape) {
+    return true
+  }
+
+  const within = <TValue extends string>(requested: TValue[] | undefined, allowed: TValue[]) => {
+    if (!requested) {
+      return true
+    }
+    const allowedSet = new Set(allowed)
+    return requested.every((candidate) => allowedSet.has(candidate))
+  }
+
+  return (
+    within(requestedShape.fields, descriptorShape.fields) &&
+    within(requestedShape.facts, descriptorShape.facts) &&
+    within(requestedShape.resources, descriptorShape.resources)
+  )
+}
+
+const toApprovedShape = ({
+  descriptorShape,
+  requestedShape,
+}: {
+  descriptorShape: ProjectionShape
+  requestedShape: RequestedProjectionShape | undefined
+}): ProjectionShape => ({
+  fields: requestedShape?.fields ?? descriptorShape.fields,
+  facts: requestedShape?.facts ?? descriptorShape.facts,
+  resources: requestedShape?.resources ?? descriptorShape.resources,
+})
+
+const createDecisionDetail = ({
+  request,
+  descriptor,
+  decision,
+  reason,
+  requirements,
+  includeApprovedShape = false,
+}: {
+  request: ProjectionRequest
+  descriptor?: ProjectionDescriptor
+  decision: ProjectionDecision
+  reason: string
+  requirements: ProjectionRequirement[]
+  includeApprovedShape?: boolean
+}): ProjectionDecisionDetail =>
+  ProjectionDecisionDetailSchema.parse({
+    requestId: request.requestId,
+    correlationId: request.correlationId,
+    sourceModuleId: request.sourceModuleId,
+    projectionId: request.projectionId,
+    decision,
+    reason,
+    requirements,
+    ...(descriptor && {
+      audience: descriptor.audience,
+      descriptorProvenance: descriptor.provenance,
+    }),
+    ...(request.provenance && {
+      requestProvenance: request.provenance,
+    }),
+    ...(descriptor &&
+      includeApprovedShape && {
+        approvedShape: toApprovedShape({
+          descriptorShape: descriptor.shape,
+          requestedShape: request.requestedShape,
+        }),
+      }),
+  })
+
+export const evaluateProjectionRequest = ({
+  request,
+  descriptorLookup,
+}: EvaluateProjectionRequestParams): ProjectionDecisionDetail => {
+  const descriptor = descriptorLookup.get(request.projectionId)
+  if (!descriptor) {
+    return createDecisionDetail({
+      request,
+      decision: 'deny',
+      reason: 'projection-descriptor-not-found',
+      requirements: [
+        ProjectionRequirementSchema.parse({
+          kind: 'projection-descriptor',
+          projectionId: request.projectionId,
+          message: 'Register a projection descriptor before evaluating requests.',
+        }),
+      ],
+    })
+  }
+
+  if (descriptor.sourceModuleId !== request.sourceModuleId) {
+    return createDecisionDetail({
+      request,
+      descriptor,
+      decision: 'deny',
+      reason: 'source-module-mismatch',
+      requirements: [
+        ProjectionRequirementSchema.parse({
+          kind: 'projection-descriptor',
+          projectionId: request.projectionId,
+          expectedSourceModuleId: descriptor.sourceModuleId,
+          actualSourceModuleId: request.sourceModuleId,
+        }),
+      ],
+    })
+  }
+
+  if (
+    !isRequestedShapeWithinDescriptor({
+      requestedShape: request.requestedShape,
+      descriptorShape: descriptor.shape,
+    })
+  ) {
+    return createDecisionDetail({
+      request,
+      descriptor,
+      decision: 'deny',
+      reason: 'projection-shape-outside-approved',
+      requirements: [
+        ProjectionRequirementSchema.parse({
+          kind: 'projection-descriptor',
+          projectionId: request.projectionId,
+          message: 'Requested shape exceeds approved projection descriptor.',
+        }),
+      ],
+    })
+  }
+
+  if (
+    !isAudienceMatch({
+      descriptorAudience: descriptor.audience,
+      requesterAudience: request.requester,
+    })
+  ) {
+    return createDecisionDetail({
+      request,
+      descriptor,
+      decision: 'deny',
+      reason: 'projection-audience-mismatch',
+      requirements: [
+        ProjectionRequirementSchema.parse({
+          kind: 'auth-grant',
+          projectionId: request.projectionId,
+          message: 'Requester audience does not match the approved projection audience.',
+        }),
+      ],
+    })
+  }
+
+  if (request.moduleSharingPolicy === 'none') {
+    return createDecisionDetail({
+      request,
+      descriptor,
+      decision: 'deny',
+      reason: 'module-sharing-policy-none',
+      requirements: [],
+    })
+  }
+
+  if (request.moduleSharingPolicy === 'ask') {
+    return createDecisionDetail({
+      request,
+      descriptor,
+      decision: 'ask',
+      reason: 'module-sharing-policy-ask',
+      requirements: [
+        ProjectionRequirementSchema.parse({
+          kind: 'human-confirmation',
+          prompt: `Share projection "${request.projectionId}" from module "${request.sourceModuleId}" with audience "${request.requester.kind}"?`,
+        }),
+      ],
+      includeApprovedShape: true,
+    })
+  }
+
+  return createDecisionDetail({
+    request,
+    descriptor,
+    decision: 'allow',
+    reason: 'module-sharing-policy-all-approved-projection',
+    requirements: [],
+    includeApprovedShape: true,
+  })
+}
+
+export const projectionBoundaryActorExtension = useExtension(PROJECTION_BOUNDARY_ACTOR_ID, ({ trigger }) => {
+  const descriptorLookup = new Map<string, ProjectionDescriptor>()
+
+  return {
+    [PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_descriptor_register](detail: unknown) {
+      const registration = ProjectionDescriptorRegistrationSchema.parse(detail)
+      descriptorLookup.set(registration.descriptor.projectionId, registration.descriptor)
+      trigger({
+        type: PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_descriptor_registered,
+        detail: registration.descriptor,
+      })
+    },
+    [PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_request_evaluate](detail: unknown) {
+      const request = ProjectionRequestSchema.parse(detail)
+      const decision = evaluateProjectionRequest({
+        request,
+        descriptorLookup,
+      })
+      trigger({
+        type: PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_decision,
+        detail: decision,
+      })
+    },
+  }
+})

--- a/src/modules/projection-boundary-actor.ts
+++ b/src/modules/projection-boundary-actor.ts
@@ -21,12 +21,43 @@ export type ModuleSharingPolicy = z.infer<typeof ModuleSharingPolicySchema>
 export const ProjectionDecisionSchema = z.enum(['allow', 'deny', 'ask'])
 export type ProjectionDecision = z.infer<typeof ProjectionDecisionSchema>
 
-export const ProjectionAudienceSchema = z
-  .object({
-    id: z.string().min(1).optional(),
-    kind: z.string().min(1),
-  })
-  .passthrough()
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z
+      .custom<Record<string, unknown>>((value) => isPlainRecord(value), {
+        message: 'Expected a plain JSON object.',
+      })
+      .pipe(z.record(z.string(), JsonValueSchema)),
+  ]),
+)
+
+const createJsonObjectWithShapeSchema = <TShape extends z.ZodRawShape>(shape: TShape) =>
+  z
+    .custom<Record<string, unknown>>((value) => isPlainRecord(value), {
+      message: 'Expected a plain JSON object.',
+    })
+    .pipe(z.object(shape).catchall(JsonValueSchema))
+
+export const ProjectionAudienceSchema = createJsonObjectWithShapeSchema({
+  id: z.string().min(1).optional(),
+  kind: z.string().min(1),
+})
 export type ProjectionAudience = z.infer<typeof ProjectionAudienceSchema>
 
 export const ProjectionShapeSchema = z.object({
@@ -43,16 +74,18 @@ export const RequestedProjectionShapeSchema = z.object({
 })
 export type RequestedProjectionShape = z.infer<typeof RequestedProjectionShapeSchema>
 
-export const ProjectionScopeSchema = z.record(z.string(), z.unknown())
+export const ProjectionScopeSchema = z
+  .custom<Record<string, unknown>>((value) => isPlainRecord(value), {
+    message: 'Expected a plain JSON object.',
+  })
+  .pipe(z.record(z.string(), JsonValueSchema))
 export type ProjectionScope = z.infer<typeof ProjectionScopeSchema>
 
-export const ProjectionProvenanceSchema = z
-  .object({
-    sourceId: z.string().min(1).optional(),
-    sourceModuleId: z.string().min(1).optional(),
-    lineage: z.array(z.string().min(1)).optional(),
-  })
-  .passthrough()
+export const ProjectionProvenanceSchema = createJsonObjectWithShapeSchema({
+  sourceId: z.string().min(1).optional(),
+  sourceModuleId: z.string().min(1).optional(),
+  lineage: z.array(z.string().min(1)).optional(),
+})
 export type ProjectionProvenance = z.infer<typeof ProjectionProvenanceSchema>
 
 export const ProjectionDescriptorSchema = z.object({
@@ -83,11 +116,9 @@ export const ProjectionRequestSchema = z.object({
 })
 export type ProjectionRequest = z.infer<typeof ProjectionRequestSchema>
 
-export const ProjectionRequirementSchema = z
-  .object({
-    kind: z.string().min(1),
-  })
-  .passthrough()
+export const ProjectionRequirementSchema = createJsonObjectWithShapeSchema({
+  kind: z.string().min(1),
+})
 export type ProjectionRequirement = z.infer<typeof ProjectionRequirementSchema>
 
 export const ProjectionDecisionDetailSchema = z.object({
@@ -109,9 +140,6 @@ type EvaluateProjectionRequestParams = {
   request: ProjectionRequest
   descriptorLookup: ReadonlyMap<string, ProjectionDescriptor>
 }
-
-const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === 'object' && !Array.isArray(value)
 
 const isJsonEqual = (left: unknown, right: unknown): boolean => {
   if (left === null || right === null) {

--- a/src/modules/projection-boundary-actor.ts
+++ b/src/modules/projection-boundary-actor.ts
@@ -110,6 +110,68 @@ type EvaluateProjectionRequestParams = {
   descriptorLookup: ReadonlyMap<string, ProjectionDescriptor>
 }
 
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const isJsonEqual = (left: unknown, right: unknown): boolean => {
+  if (left === null || right === null) {
+    return left === right
+  }
+
+  const leftType = typeof left
+  const rightType = typeof right
+  if (leftType !== rightType) {
+    return false
+  }
+
+  if (leftType === 'string' || leftType === 'number' || leftType === 'boolean') {
+    return Object.is(left, right)
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false
+    }
+    return left.every((value, index) => isJsonEqual(value, right[index]))
+  }
+
+  if (isPlainRecord(left) && isPlainRecord(right)) {
+    const leftKeys = Object.keys(left)
+    const rightKeys = Object.keys(right)
+    if (leftKeys.length !== rightKeys.length) {
+      return false
+    }
+
+    return leftKeys.every((key) => Object.hasOwn(right, key) && isJsonEqual(left[key], right[key]))
+  }
+
+  return false
+}
+
+const isScopeCompatible = ({
+  descriptorScope,
+  requestScope,
+}: {
+  descriptorScope: ProjectionScope
+  requestScope: ProjectionScope | undefined
+}) => {
+  if (!requestScope) {
+    return false
+  }
+
+  for (const [scopeKey, descriptorValue] of Object.entries(descriptorScope)) {
+    if (!Object.hasOwn(requestScope, scopeKey)) {
+      return false
+    }
+    const requestValue = requestScope[scopeKey]
+    if (!isJsonEqual(descriptorValue, requestValue)) {
+      return false
+    }
+  }
+
+  return true
+}
+
 const isAudienceMatch = ({
   descriptorAudience,
   requesterAudience,
@@ -160,11 +222,17 @@ const toApprovedShape = ({
 }: {
   descriptorShape: ProjectionShape
   requestedShape: RequestedProjectionShape | undefined
-}): ProjectionShape => ({
-  fields: requestedShape?.fields ?? descriptorShape.fields,
-  facts: requestedShape?.facts ?? descriptorShape.facts,
-  resources: requestedShape?.resources ?? descriptorShape.resources,
-})
+}): ProjectionShape => {
+  if (!requestedShape) {
+    return descriptorShape
+  }
+
+  return {
+    fields: requestedShape.fields ?? [],
+    facts: requestedShape.facts ?? [],
+    resources: requestedShape.resources ?? [],
+  }
+}
 
 const createDecisionDetail = ({
   request,
@@ -237,6 +305,30 @@ export const evaluateProjectionRequest = ({
           projectionId: request.projectionId,
           expectedSourceModuleId: descriptor.sourceModuleId,
           actualSourceModuleId: request.sourceModuleId,
+        }),
+      ],
+    })
+  }
+
+  if (
+    descriptor.scope &&
+    !isScopeCompatible({
+      descriptorScope: descriptor.scope,
+      requestScope: request.scope,
+    })
+  ) {
+    return createDecisionDetail({
+      request,
+      descriptor,
+      decision: 'deny',
+      reason: 'projection-scope-mismatch',
+      requirements: [
+        ProjectionRequirementSchema.parse({
+          kind: 'auth-grant',
+          projectionId: request.projectionId,
+          message: 'Projection request scope does not satisfy descriptor scope.',
+          expectedScope: descriptor.scope,
+          actualScope: request.scope ?? null,
         }),
       ],
     })

--- a/src/modules/tests/projection-boundary-actor.spec.ts
+++ b/src/modules/tests/projection-boundary-actor.spec.ts
@@ -50,6 +50,31 @@ const ramStandSupplierDescriptor: ProjectionDescriptor = ProjectionDescriptorSch
   },
 })
 
+const ramStandSupplierScopedDescriptor: ProjectionDescriptor = ProjectionDescriptorSchema.parse({
+  projectionId: 'ram-stand-supplier-scoped-v1',
+  sourceModuleId: 'ram-stand',
+  audience: {
+    kind: 'supplier-network',
+    id: 'supplier-network-1',
+  },
+  shape: {
+    fields: ['supplierSku'],
+    facts: ['stock-level'],
+    resources: ['purchase-orders'],
+  },
+  scope: {
+    region: 'us-west',
+    channel: 'supplier-network',
+    controls: {
+      exportClass: 'regulated',
+    },
+  },
+  provenance: {
+    sourceId: 'ram-stand-private-state',
+    sourceModuleId: 'ram-stand',
+  },
+})
+
 const ramStandCustomerDescriptor: ProjectionDescriptor = ProjectionDescriptorSchema.parse({
   projectionId: 'ram-stand-customer-v1',
   sourceModuleId: 'ram-stand',
@@ -197,12 +222,14 @@ const createRamStandRequest = ({
   moduleSharingPolicy = 'all',
   sourceModuleId = 'ram-stand',
   requestedShape,
+  scope,
 }: {
   projectionId?: string
   requester?: ProjectionDescriptor['audience']
   moduleSharingPolicy?: ProjectionRequest['moduleSharingPolicy']
   sourceModuleId?: string
   requestedShape?: ProjectionRequest['requestedShape']
+  scope?: ProjectionRequest['scope']
 } = {}) =>
   ProjectionRequestSchema.parse({
     requestId: `req-${Math.random().toString(36).slice(2)}`,
@@ -212,6 +239,7 @@ const createRamStandRequest = ({
     requester,
     moduleSharingPolicy,
     ...(requestedShape && { requestedShape }),
+    ...(scope && { scope }),
     provenance: {
       sourceId: 'ram-stand-private-state',
       sourceModuleId: 'ram-stand',
@@ -247,6 +275,136 @@ describe('projection boundary actor extension', () => {
       fields: ['supplierSku'],
       facts: ['stock-level'],
       resources: ['purchase-orders'],
+    })
+  })
+
+  test('matching descriptor and request scope allows under module sharing policy all', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierScopedDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandSupplierScopedDescriptor.projectionId,
+        requester: ramStandSupplierScopedDescriptor.audience,
+        moduleSharingPolicy: 'all',
+        scope: {
+          region: 'us-west',
+          channel: 'supplier-network',
+          controls: {
+            exportClass: 'regulated',
+          },
+          requestId: 'scope-extra-ok',
+        },
+      }),
+    })
+
+    expect(decision.decision).toBe('allow')
+    expect(decision.reason).toBe('module-sharing-policy-all-approved-projection')
+  })
+
+  test('missing request scope denies when descriptor scope exists', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierScopedDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandSupplierScopedDescriptor.projectionId,
+        requester: ramStandSupplierScopedDescriptor.audience,
+        moduleSharingPolicy: 'all',
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('projection-scope-mismatch')
+    expect(decision.requirements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'auth-grant',
+          projectionId: ramStandSupplierScopedDescriptor.projectionId,
+          expectedScope: ramStandSupplierScopedDescriptor.scope,
+          actualScope: null,
+        }),
+      ]),
+    )
+  })
+
+  test('mismatched request scope denies when descriptor scope exists', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierScopedDescriptor)
+
+    const mismatchedScope = {
+      region: 'us-east',
+      channel: 'supplier-network',
+      controls: {
+        exportClass: 'regulated',
+      },
+    }
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandSupplierScopedDescriptor.projectionId,
+        requester: ramStandSupplierScopedDescriptor.audience,
+        moduleSharingPolicy: 'all',
+        scope: mismatchedScope,
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('projection-scope-mismatch')
+    expect(decision.requirements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'auth-grant',
+          projectionId: ramStandSupplierScopedDescriptor.projectionId,
+          expectedScope: ramStandSupplierScopedDescriptor.scope,
+          actualScope: mismatchedScope,
+        }),
+      ]),
+    )
+  })
+
+  test('module sharing policy all does not bypass scope mismatch', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierScopedDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandSupplierScopedDescriptor.projectionId,
+        requester: ramStandSupplierScopedDescriptor.audience,
+        moduleSharingPolicy: 'all',
+        scope: {
+          region: 'us-west',
+          channel: 'supplier-network',
+        },
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('projection-scope-mismatch')
+  })
+
+  test('partial requested shape with only fields does not inherit descriptor facts or resources', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        moduleSharingPolicy: 'all',
+        requestedShape: {
+          fields: ['supplierSku'],
+        },
+      }),
+    })
+
+    expect(decision.decision).toBe('allow')
+    expect(decision.approvedShape).toEqual({
+      fields: ['supplierSku'],
+      facts: [],
+      resources: [],
     })
   })
 

--- a/src/modules/tests/projection-boundary-actor.spec.ts
+++ b/src/modules/tests/projection-boundary-actor.spec.ts
@@ -4,12 +4,15 @@ import { behavioral, SNAPSHOT_MESSAGE_KINDS, type SnapshotMessage, useInstaller 
 import { projectionBoundaryActorExtension } from '../../modules.ts'
 import {
   PROJECTION_BOUNDARY_ACTOR_EVENTS,
+  ProjectionAudienceSchema,
   type ProjectionDecisionDetail,
   ProjectionDecisionDetailSchema,
   type ProjectionDescriptor,
   ProjectionDescriptorSchema,
+  ProjectionProvenanceSchema,
   type ProjectionRequest,
   ProjectionRequestSchema,
+  ProjectionRequirementSchema,
   toProjectionBoundaryActorEventType,
 } from '../projection-boundary-actor.ts'
 
@@ -67,6 +70,35 @@ const ramStandSupplierScopedDescriptor: ProjectionDescriptor = ProjectionDescrip
     channel: 'supplier-network',
     controls: {
       exportClass: 'regulated',
+    },
+  },
+  provenance: {
+    sourceId: 'ram-stand-private-state',
+    sourceModuleId: 'ram-stand',
+  },
+})
+
+const ramStandSupplierNestedScopeDescriptor: ProjectionDescriptor = ProjectionDescriptorSchema.parse({
+  projectionId: 'ram-stand-supplier-nested-scope-v1',
+  sourceModuleId: 'ram-stand',
+  audience: {
+    kind: 'supplier-network',
+    id: 'supplier-network-1',
+  },
+  shape: {
+    fields: ['supplierSku'],
+    facts: ['stock-level'],
+    resources: ['purchase-orders'],
+  },
+  scope: {
+    region: 'us-west',
+    channel: 'supplier-network',
+    controls: {
+      exportClass: 'regulated',
+      modes: ['bulk', { tier: 2, flags: [true, null, 'ok'] }],
+      limits: {
+        maxOrdersPerDay: 50,
+      },
     },
   },
   provenance: {
@@ -299,6 +331,154 @@ describe('projection boundary actor extension', () => {
       }),
     })
 
+    expect(decision.decision).toBe('allow')
+    expect(decision.reason).toBe('module-sharing-policy-all-approved-projection')
+  })
+
+  test('ProjectionRequestSchema rejects a function inside scope', () => {
+    const parseResult = ProjectionRequestSchema.safeParse({
+      ...createRamStandRequest(),
+      scope: {
+        region: 'us-west',
+        invalidFn: () => 'nope',
+      },
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('ProjectionRequestSchema rejects NaN inside scope', () => {
+    const parseResult = ProjectionRequestSchema.safeParse({
+      ...createRamStandRequest(),
+      scope: {
+        region: 'us-west',
+        invalidNumber: Number.NaN,
+      },
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('ProjectionRequestSchema rejects Infinity inside scope', () => {
+    const parseResult = ProjectionRequestSchema.safeParse({
+      ...createRamStandRequest(),
+      scope: {
+        region: 'us-west',
+        invalidNumber: Number.POSITIVE_INFINITY,
+      },
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('ProjectionRequestSchema rejects a Date inside scope', () => {
+    const parseResult = ProjectionRequestSchema.safeParse({
+      ...createRamStandRequest(),
+      scope: {
+        region: 'us-west',
+        invalidDate: new Date('2026-04-20T00:00:00.000Z'),
+      },
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('provenance extra fields reject a function', () => {
+    const parseResult = ProjectionProvenanceSchema.safeParse({
+      sourceId: 'ram-stand-private-state',
+      sourceModuleId: 'ram-stand',
+      extraFn: () => 'nope',
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('requirement extra fields reject a function', () => {
+    const parseResult = ProjectionRequirementSchema.safeParse({
+      kind: 'auth-grant',
+      extraFn: () => 'nope',
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('audience extra fields reject a function', () => {
+    const parseResult = ProjectionAudienceSchema.safeParse({
+      kind: 'supplier-network',
+      id: 'supplier-network-1',
+      extraFn: () => 'nope',
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('invalid projection request with non-JSON scope emits feedback_error and no projection decision', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierScopedDescriptor)
+    const beforeSnapshots = harness.snapshots.length
+    const beforeEvents = harness.events.length
+
+    const invalidRequest = {
+      ...createRamStandRequest({
+        projectionId: ramStandSupplierScopedDescriptor.projectionId,
+        requester: ramStandSupplierScopedDescriptor.audience,
+      }),
+      scope: {
+        region: 'us-west',
+        channel: 'supplier-network',
+        controls: {
+          exportClass: 'regulated',
+        },
+        invalidFn: () => 'nope',
+      },
+    }
+
+    harness.trigger({
+      type: requestEvaluateEventType,
+      detail: invalidRequest as unknown,
+    })
+
+    const feedbackError = await waitForFeedbackError({
+      snapshots: harness.snapshots,
+      type: requestEvaluateEventType,
+      after: beforeSnapshots,
+    })
+    expect(feedbackError.error).toContain('scope')
+
+    const emittedDecisions = harness.events.slice(beforeEvents).filter((event) => event.type === decisionEventType)
+    expect(emittedDecisions).toHaveLength(0)
+  })
+
+  test('valid nested JSON scope parses and remains compatible for allow decisions', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierNestedScopeDescriptor)
+
+    const request = ProjectionRequestSchema.parse({
+      ...createRamStandRequest({
+        projectionId: ramStandSupplierNestedScopeDescriptor.projectionId,
+        requester: ramStandSupplierNestedScopeDescriptor.audience,
+      }),
+      scope: {
+        region: 'us-west',
+        channel: 'supplier-network',
+        controls: {
+          exportClass: 'regulated',
+          modes: ['bulk', { tier: 2, flags: [true, null, 'ok'] }],
+          limits: {
+            maxOrdersPerDay: 50,
+          },
+        },
+        trace: {
+          attempt: 1,
+          labels: ['slice-6', { state: 'ok' }],
+        },
+      },
+    })
+
+    const decision = await evaluateRequest({
+      harness,
+      request,
+    })
     expect(decision.decision).toBe('allow')
     expect(decision.reason).toBe('module-sharing-policy-all-approved-projection')
   })

--- a/src/modules/tests/projection-boundary-actor.spec.ts
+++ b/src/modules/tests/projection-boundary-actor.spec.ts
@@ -1,0 +1,466 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { behavioral, SNAPSHOT_MESSAGE_KINDS, type SnapshotMessage, useInstaller } from '../../behavioral.ts'
+import { projectionBoundaryActorExtension } from '../../modules.ts'
+import {
+  PROJECTION_BOUNDARY_ACTOR_EVENTS,
+  type ProjectionDecisionDetail,
+  ProjectionDecisionDetailSchema,
+  type ProjectionDescriptor,
+  ProjectionDescriptorSchema,
+  type ProjectionRequest,
+  ProjectionRequestSchema,
+  toProjectionBoundaryActorEventType,
+} from '../projection-boundary-actor.ts'
+
+type ObservedEvent = { type: string; detail?: unknown }
+type Harness = {
+  events: ObservedEvent[]
+  snapshots: SnapshotMessage[]
+  trigger: (event: { type: string; detail?: unknown }) => void
+}
+
+const descriptorRegisterEventType = toProjectionBoundaryActorEventType(
+  PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_descriptor_register,
+)
+const descriptorRegisteredEventType = toProjectionBoundaryActorEventType(
+  PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_descriptor_registered,
+)
+const requestEvaluateEventType = toProjectionBoundaryActorEventType(
+  PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_request_evaluate,
+)
+const decisionEventType = toProjectionBoundaryActorEventType(PROJECTION_BOUNDARY_ACTOR_EVENTS.projection_decision)
+
+const ramStandSupplierDescriptor: ProjectionDescriptor = ProjectionDescriptorSchema.parse({
+  projectionId: 'ram-stand-supplier-v1',
+  sourceModuleId: 'ram-stand',
+  audience: {
+    kind: 'supplier-network',
+    id: 'supplier-network-1',
+  },
+  shape: {
+    fields: ['supplierSku', 'inventoryStatus', 'reorderThreshold'],
+    facts: ['stock-level'],
+    resources: ['purchase-orders'],
+  },
+  provenance: {
+    sourceId: 'ram-stand-private-state',
+    sourceModuleId: 'ram-stand',
+    lineage: ['stock-feed', 'ops-console'],
+  },
+})
+
+const ramStandCustomerDescriptor: ProjectionDescriptor = ProjectionDescriptorSchema.parse({
+  projectionId: 'ram-stand-customer-v1',
+  sourceModuleId: 'ram-stand',
+  audience: {
+    kind: 'customer-network',
+    id: 'customer-network-1',
+  },
+  shape: {
+    fields: ['catalogTitle', 'availableForOrder'],
+    facts: ['public-stock-band'],
+    resources: ['catalog'],
+  },
+  provenance: {
+    sourceId: 'ram-stand-private-state',
+    sourceModuleId: 'ram-stand',
+  },
+})
+
+const ramStandOrganizerDescriptor: ProjectionDescriptor = ProjectionDescriptorSchema.parse({
+  projectionId: 'ram-stand-organizer-v1',
+  sourceModuleId: 'ram-stand',
+  audience: {
+    kind: 'market-organizer-network',
+    id: 'market-organizer-network-1',
+  },
+  shape: {
+    fields: ['boothId', 'inspectionStatus'],
+    facts: ['compliance-attestation'],
+    resources: ['logistics-manifest'],
+  },
+  provenance: {
+    sourceId: 'ram-stand-private-state',
+    sourceModuleId: 'ram-stand',
+  },
+})
+
+const createHarness = (): Harness => {
+  const events: ObservedEvent[] = []
+  const snapshots: SnapshotMessage[] = []
+  const { addBThread, trigger, useFeedback, useSnapshot, reportSnapshot } = behavioral()
+  const install = useInstaller({
+    trigger,
+    useSnapshot,
+    reportSnapshot,
+    addBThread,
+    ttlMs: 1_000,
+  })
+
+  useFeedback(install(projectionBoundaryActorExtension))
+  useFeedback({
+    [descriptorRegisteredEventType]: (detail: unknown) => {
+      events.push({ type: descriptorRegisteredEventType, detail })
+    },
+    [decisionEventType]: (detail: unknown) => {
+      events.push({ type: decisionEventType, detail })
+    },
+  })
+  useSnapshot((snapshot) => {
+    snapshots.push(snapshot)
+  })
+
+  return { events, snapshots, trigger }
+}
+
+const waitForEvent = async ({
+  events,
+  type,
+  after = 0,
+  timeoutMs = 3_000,
+}: {
+  events: ObservedEvent[]
+  type: string
+  after?: number
+  timeoutMs?: number
+}) => {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt <= timeoutMs) {
+    const match = events.slice(after).find((event) => event.type === type)
+    if (match) {
+      return match
+    }
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for event "${type}"`)
+}
+
+const waitForFeedbackError = async ({
+  snapshots,
+  type,
+  after = 0,
+  timeoutMs = 3_000,
+}: {
+  snapshots: SnapshotMessage[]
+  type: string
+  after?: number
+  timeoutMs?: number
+}) => {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt <= timeoutMs) {
+    const match = snapshots
+      .slice(after)
+      .find((snapshot) => snapshot.kind === SNAPSHOT_MESSAGE_KINDS.feedback_error && snapshot.type === type)
+    if (match && match.kind === SNAPSHOT_MESSAGE_KINDS.feedback_error) {
+      return match
+    }
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for feedback_error snapshot for "${type}"`)
+}
+
+const registerDescriptor = (harness: Harness, descriptor: ProjectionDescriptor) => {
+  harness.trigger({
+    type: descriptorRegisterEventType,
+    detail: {
+      descriptor,
+    },
+  })
+}
+
+const evaluateRequest = async ({
+  harness,
+  request,
+  after,
+}: {
+  harness: Harness
+  request: ProjectionRequest
+  after?: number
+}) => {
+  const before = after ?? harness.events.length
+  harness.trigger({
+    type: requestEvaluateEventType,
+    detail: request,
+  })
+  const decisionEvent = await waitForEvent({
+    events: harness.events,
+    type: decisionEventType,
+    after: before,
+  })
+  return ProjectionDecisionDetailSchema.parse(decisionEvent.detail)
+}
+
+const createRamStandRequest = ({
+  projectionId = ramStandSupplierDescriptor.projectionId,
+  requester = ramStandSupplierDescriptor.audience,
+  moduleSharingPolicy = 'all',
+  sourceModuleId = 'ram-stand',
+  requestedShape,
+}: {
+  projectionId?: string
+  requester?: ProjectionDescriptor['audience']
+  moduleSharingPolicy?: ProjectionRequest['moduleSharingPolicy']
+  sourceModuleId?: string
+  requestedShape?: ProjectionRequest['requestedShape']
+} = {}) =>
+  ProjectionRequestSchema.parse({
+    requestId: `req-${Math.random().toString(36).slice(2)}`,
+    correlationId: `corr-${Math.random().toString(36).slice(2)}`,
+    sourceModuleId,
+    projectionId,
+    requester,
+    moduleSharingPolicy,
+    ...(requestedShape && { requestedShape }),
+    provenance: {
+      sourceId: 'ram-stand-private-state',
+      sourceModuleId: 'ram-stand',
+    },
+  })
+
+describe('projection boundary actor extension', () => {
+  test('keeps a flat actor file and does not create a nested projection implementation folder', async () => {
+    expect(await Bun.file('src/modules/projection-boundary-actor.ts').exists()).toBe(true)
+    expect(existsSync('src/modules/projection-boundary-actor')).toBe(false)
+  })
+
+  test('module sharing policy all allows a valid approved RAM Stand supplier projection', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        moduleSharingPolicy: 'all',
+        requestedShape: {
+          fields: ['supplierSku'],
+          facts: ['stock-level'],
+          resources: ['purchase-orders'],
+        },
+      }),
+    })
+
+    expect(decision.decision).toBe('allow')
+    expect(decision.reason).toBe('module-sharing-policy-all-approved-projection')
+    expect(decision.requirements).toEqual([])
+    expect(decision.approvedShape).toEqual({
+      fields: ['supplierSku'],
+      facts: ['stock-level'],
+      resources: ['purchase-orders'],
+    })
+  })
+
+  test('module sharing policy none denies projection of source module data', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        moduleSharingPolicy: 'none',
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('module-sharing-policy-none')
+    expect(decision.requirements).toEqual([])
+  })
+
+  test('module sharing policy ask returns ask with human-confirmation requirement', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        moduleSharingPolicy: 'ask',
+      }),
+    })
+
+    expect(decision.decision).toBe('ask')
+    expect(decision.reason).toBe('module-sharing-policy-ask')
+    expect(decision.requirements).toHaveLength(1)
+    expect(decision.requirements[0]).toEqual(
+      expect.objectContaining({
+        kind: 'human-confirmation',
+      }),
+    )
+  })
+
+  test('all does not expose RAM Stand fields outside the approved projection descriptor shape', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        moduleSharingPolicy: 'all',
+        requestedShape: {
+          fields: ['supplierSku', 'secretMargin'],
+          facts: ['stock-level'],
+          resources: ['purchase-orders'],
+        },
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('projection-shape-outside-approved')
+    expect(decision.requirements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'projection-descriptor',
+        }),
+      ]),
+    )
+  })
+
+  test('audience-specific RAM Stand projection descriptors remain distinct', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+    registerDescriptor(harness, ramStandCustomerDescriptor)
+    registerDescriptor(harness, ramStandOrganizerDescriptor)
+
+    const supplierDecision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandSupplierDescriptor.projectionId,
+        requester: ramStandSupplierDescriptor.audience,
+      }),
+    })
+    expect(supplierDecision.decision).toBe('allow')
+
+    const customerDecision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandCustomerDescriptor.projectionId,
+        requester: ramStandCustomerDescriptor.audience,
+      }),
+    })
+    expect(customerDecision.decision).toBe('allow')
+
+    const organizerDecision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandOrganizerDescriptor.projectionId,
+        requester: ramStandOrganizerDescriptor.audience,
+      }),
+    })
+    expect(organizerDecision.decision).toBe('allow')
+
+    const mismatchDecision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: ramStandSupplierDescriptor.projectionId,
+        requester: ramStandCustomerDescriptor.audience,
+      }),
+    })
+    expect(mismatchDecision.decision).toBe('deny')
+    expect(mismatchDecision.reason).toBe('projection-audience-mismatch')
+  })
+
+  test('unknown projection id denies projection request', async () => {
+    const harness = createHarness()
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        projectionId: 'ram-stand-unknown-v1',
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('projection-descriptor-not-found')
+  })
+
+  test('source module mismatch denies projection request', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        sourceModuleId: 'other-module',
+      }),
+    })
+
+    expect(decision.decision).toBe('deny')
+    expect(decision.reason).toBe('source-module-mismatch')
+  })
+
+  test('invalid projection request emits diagnostics snapshot evidence and keeps provenance unchanged', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+    const before = harness.snapshots.length
+    const invalidRequest = {
+      requestId: 'req-invalid',
+      sourceModuleId: 'ram-stand',
+      projectionId: ramStandSupplierDescriptor.projectionId,
+      requester: ramStandSupplierDescriptor.audience,
+      moduleSharingPolicy: 'all',
+      provenance: {
+        sourceId: 'ram-stand-private-state',
+      },
+    } as const
+
+    harness.trigger({
+      type: requestEvaluateEventType,
+      detail: invalidRequest as unknown,
+    })
+
+    const feedbackError = await waitForFeedbackError({
+      snapshots: harness.snapshots,
+      type: requestEvaluateEventType,
+      after: before,
+    })
+    expect(feedbackError.error).toContain('correlationId')
+    expect(feedbackError.detail).toEqual(
+      expect.objectContaining({
+        provenance: expect.objectContaining({
+          sourceId: 'ram-stand-private-state',
+        }),
+      }),
+    )
+  })
+
+  test('decision output includes decision, reason, and requirements', async () => {
+    const harness = createHarness()
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const decision: ProjectionDecisionDetail = await evaluateRequest({
+      harness,
+      request: createRamStandRequest({
+        moduleSharingPolicy: 'ask',
+      }),
+    })
+
+    expect(typeof decision.decision).toBe('string')
+    expect(typeof decision.reason).toBe('string')
+    expect(Array.isArray(decision.requirements)).toBe(true)
+    expect(decision).toEqual(
+      expect.objectContaining({
+        decision: 'ask',
+        reason: 'module-sharing-policy-ask',
+      }),
+    )
+  })
+
+  test('registered descriptors and decisions are replay-safe JSON-shaped data', async () => {
+    const harness = createHarness()
+    const beforeRegistration = harness.events.length
+    registerDescriptor(harness, ramStandSupplierDescriptor)
+
+    const registeredEvent = await waitForEvent({
+      events: harness.events,
+      type: descriptorRegisteredEventType,
+      after: beforeRegistration,
+    })
+    const registeredDescriptor = ProjectionDescriptorSchema.parse(registeredEvent.detail)
+    expect(JSON.parse(JSON.stringify(registeredDescriptor))).toEqual(registeredDescriptor)
+
+    const decision = await evaluateRequest({
+      harness,
+      request: createRamStandRequest(),
+    })
+    expect(JSON.parse(JSON.stringify(decision))).toEqual(decision)
+  })
+})


### PR DESCRIPTION
## Context

- Implements MSS/module runtime redesign Slice 6 by introducing a projection boundary actor as the runtime semantic gate between source module state and projection exposure.
- Fixes #326.

## Summary

- Added flat module actor `src/modules/projection-boundary-actor.ts` with JSON-shaped descriptor/request/decision schemas.
- Implemented policy mapping from module sharing policy (`all | none | ask`) to request-level decisions (`allow | deny | ask`) with explicit reason and requirements.
- Added descriptor registration and request evaluation events through `useExtension` actor surface.
- Added projection shape and audience enforcement so `all` still respects approved descriptor bounds.
- Added focused tests with RAM Stand fixture vocabulary for supplier/customer/market-organizer projection distinctions.
- Exported new actor from `src/modules.ts`.

## Changed Files

- `src/modules/projection-boundary-actor.ts`
- `src/modules/tests/projection-boundary-actor.spec.ts`
- `src/modules.ts`

## Validation

- Targeted tests:
  - `bun test src/modules/tests/projection-boundary-actor.spec.ts`
  - `bun skills/plaited-context/scripts/module-patterns.ts '{"files":["src/modules/projection-boundary-actor.ts"]}'`
  - `bun skills/plaited-context/scripts/module-flow.ts '{"files":["src/modules/projection-boundary-actor.ts"],"format":"json"}'`
  - `bun skills/plaited-context/scripts/module-flow.ts '{"files":["src/modules/projection-boundary-actor.ts"],"format":"mermaid"}'`
  - `bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["src/modules/projection-boundary-actor.ts","src/modules/tests"],"includeWorktrees":true}'`
  - `bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/projection-boundary-actor.ts","operations":[{"type":"symbols"}]}'`
  - `bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/projection-boundary-actor.ts","operations":[{"type":"references","line":336,"character":23}]}'`
  - `bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/projection-boundary-actor.ts","operations":[{"type":"definition","line":336,"character":23}]}'`
- `bun --bun tsc --noEmit`: pass

## Known Failures / Drift

- None observed in this slice.

## Review Notes / Residual Risks

- Projection descriptors are in-memory runtime state in this slice; no persistence/replay ledger is included yet.
- Requirement kind shape is intentionally extensible; future slices should standardize requirement payload contracts across actors.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
