### PR TITLE
feat(modules): add module program admission actor

### DIFF
--- a/.agents/skills/plaited-development/SKILL.md
+++ b/.agents/skills/plaited-development/SKILL.md
@@ -123,6 +123,13 @@ git merge --ff-only origin/dev
 - `src/modules.ts` is the public modules boundary.
 - Core module actors should be single flat files under `src/modules/` unless a newer prompt says
   otherwise.
+- `src/modules/*.ts` files are core runtime module actors, not user-facing module programs.
+- User/developer-authored work should be called module programs until admitted.
+- Projection views are audience-specific governed views, not independent source modules unless
+  separate state/provenance exists.
+- Access requests in module descriptors are asks and review metadata, not grants.
+- Skill/CLI/inference/external-service declarations remain metadata until a later grant policy path
+  explicitly allows them.
 - Do not create nested `src/modules/<feature>/` implementation folders for these slices.
 - Do not preserve legacy module files just to avoid migration when the prompt requires replacement.
 - Review Slice 5 and later work against the exact files and forbidden paths in

--- a/skills/mss-module-review/SKILL.md
+++ b/skills/mss-module-review/SKILL.md
@@ -60,7 +60,15 @@ and a configured `"dbPath"` when findings/evidence should be persisted.
 ## Review Checklist
 
 - flat `src/modules/*.ts` file boundary
+- `src/modules/*.ts` means core runtime module actors, not user-facing module
+  programs
+- user/developer-authored proposals remain module programs until admitted
+- `src/modules.ts` remains the public modules boundary
 - forbidden nested module implementation folders
+- projection views are governed audience views of one source module program
+  unless separate state/provenance is explicit
+- declared access requests are asks, not grants, and remain metadata unless a
+  later grant path exists
 - external boundary vs internal `useExtension(...)` feedback/control parsing
 - no internal handler `safeParse(...)` silent drops
 - no internal handler `ZodError` recovery

--- a/skills/plaited-runtime/SKILL.md
+++ b/skills/plaited-runtime/SKILL.md
@@ -60,7 +60,17 @@ initialized or a `dbPath` is provided for the review run.
 ## Module Actor Boundary Rules
 
 - Core modules under `src/modules` are flat single TypeScript files.
+- `src/modules/*.ts` files are core runtime module actors, not user-facing
+  module programs.
+- User/developer-authored proposals should be called module programs until
+  admitted by runtime policy.
 - Do not create nested module implementation folders under `src/modules`.
+- `src/modules.ts` remains the public modules boundary.
+- Audience-specific projection views are governed projections, not independent
+  source modules unless they own separate state/provenance.
+- Declared access requests in module descriptors are asks, not grants.
+- Skill/CLI/inference/external-service declarations are review metadata until a
+  later grant policy path allows them.
 - External boundary ingress should parse with `.parse(...)` inside `try/catch`
   and publish diagnostics/snapshots.
 - Internal `useExtension(...)` feedback/control handlers parse strictly and

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,4 +1,5 @@
 export * from './modules/execution-process-actor.ts'
 export * from './modules/inference-websocket-runtime-actor.ts'
+export * from './modules/module-program-admission.ts'
 export * from './modules/projection-boundary-actor.ts'
 export * from './modules/ui-websocket-runtime-actor.ts'

--- a/src/modules/module-program-admission.ts
+++ b/src/modules/module-program-admission.ts
@@ -1,0 +1,476 @@
+import * as z from 'zod'
+import { useExtension } from '../behavioral.ts'
+import { keyMirror } from '../utils.ts'
+import { JsonValueSchema, ModuleSharingPolicySchema, ProjectionDescriptorSchema } from './projection-boundary-actor.ts'
+
+export const MODULE_PROGRAM_ADMISSION_ACTOR_ID = 'module_program_admission_actor'
+
+export const MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS = keyMirror('descriptor_evaluate', 'decision')
+
+export const toModuleProgramAdmissionActorEventType = <TEvent extends string>(
+  event: TEvent,
+): `${typeof MODULE_PROGRAM_ADMISSION_ACTOR_ID}:${TEvent}` => `${MODULE_PROGRAM_ADMISSION_ACTOR_ID}:${event}`
+
+const createJsonObjectWithShapeSchema = <TShape extends z.ZodRawShape>(shape: TShape) =>
+  z.object(shape).catchall(JsonValueSchema)
+
+const ModuleProgramAccessModeSchema = z.enum(['read', 'write', 'execute'])
+
+export const ModuleProgramSourceSchema = createJsonObjectWithShapeSchema({
+  kind: z.enum(['local-file', 'generated', 'external-reference']),
+  path: z.string().min(1).optional(),
+  issue: z.number().int().positive().optional(),
+  commit: z.string().min(1).optional(),
+})
+export type ModuleProgramSource = z.infer<typeof ModuleProgramSourceSchema>
+
+export const ModuleProgramProvenanceSchema = createJsonObjectWithShapeSchema({
+  createdBy: z.string().min(1).optional(),
+  createdFromIssue: z.number().int().positive().optional(),
+  createdFromPrompt: z.string().min(1).optional(),
+  reviewedBy: z.array(z.string().min(1)).optional(),
+})
+export type ModuleProgramProvenance = z.infer<typeof ModuleProgramProvenanceSchema>
+
+export const ModuleProgramMssTagsSchema = z.object({
+  content: z.array(z.string().min(1)).min(1),
+  structure: z.array(z.string().min(1)).min(1),
+  mechanics: z.array(z.string().min(1)).min(1),
+  boundary: z.array(z.string().min(1)).min(1),
+  scale: z.array(z.string().min(1)).min(1),
+})
+export type ModuleProgramMssTags = z.infer<typeof ModuleProgramMssTagsSchema>
+
+const ModuleProjectionReadAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('module-projection-read'),
+  targetModuleId: z.string().min(1),
+  projectionId: z.string().min(1),
+  reason: z.string().min(1).optional(),
+})
+
+const ModuleReadAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('module-read'),
+  targetModuleId: z.string().min(1),
+  scope: z.enum(['projection', 'state', 'unrestricted']).optional(),
+  reason: z.string().min(1).optional(),
+})
+
+const SkillUseAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('skill-use'),
+  skillName: z.string().min(1),
+  access: ModuleProgramAccessModeSchema.optional(),
+  reason: z.string().min(1).optional(),
+})
+
+const CliUseAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('cli-use'),
+  command: z.string().min(1),
+  access: ModuleProgramAccessModeSchema.optional(),
+  allowedPaths: z.array(z.string().min(1)).optional(),
+  reason: z.string().min(1).optional(),
+})
+
+const InferenceUseAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('inference-use'),
+  modelRole: z.string().min(1),
+  inputBoundary: z.string().min(1),
+  outputBoundary: z.string().min(1),
+  reason: z.string().min(1).optional(),
+})
+
+const SelfSpawnAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('self-spawn'),
+  maxConcurrent: z.number().int().positive().optional(),
+  access: ModuleProgramAccessModeSchema.optional(),
+  reason: z.string().min(1).optional(),
+})
+
+const NetworkApiUseAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('network-api-use'),
+  scope: z.enum(['bounded', 'unbounded']).optional(),
+  allowedHosts: z.array(z.string().min(1)).optional(),
+  reason: z.string().min(1).optional(),
+})
+
+const ExternalServiceReferenceAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('external-service-reference'),
+  service: z.string().min(1),
+  access: ModuleProgramAccessModeSchema.optional(),
+  reason: z.string().min(1).optional(),
+})
+
+const ProcessExecutionAccessRequestSchema = createJsonObjectWithShapeSchema({
+  kind: z.literal('process-execution'),
+  command: z.string().min(1),
+  reason: z.string().min(1).optional(),
+})
+
+export const ModuleProgramAccessRequestSchema = z.discriminatedUnion('kind', [
+  ModuleProjectionReadAccessRequestSchema,
+  ModuleReadAccessRequestSchema,
+  SkillUseAccessRequestSchema,
+  CliUseAccessRequestSchema,
+  InferenceUseAccessRequestSchema,
+  SelfSpawnAccessRequestSchema,
+  NetworkApiUseAccessRequestSchema,
+  ExternalServiceReferenceAccessRequestSchema,
+  ProcessExecutionAccessRequestSchema,
+])
+export type ModuleProgramAccessRequest = z.infer<typeof ModuleProgramAccessRequestSchema>
+
+export const ModuleProgramValidationMetadataSchema = createJsonObjectWithShapeSchema({
+  tests: z.array(z.string().min(1)).optional(),
+  commands: z.array(z.string().min(1)).optional(),
+  notes: z.array(z.string().min(1)).optional(),
+})
+export type ModuleProgramValidationMetadata = z.infer<typeof ModuleProgramValidationMetadataSchema>
+
+export const ModuleProgramDescriptorSchema = createJsonObjectWithShapeSchema({
+  programId: z.string().min(1),
+  sourceModuleId: z.string().min(1).optional(),
+  name: z.string().min(1),
+  version: z.string().min(1),
+  source: ModuleProgramSourceSchema,
+  provenance: ModuleProgramProvenanceSchema,
+  mssTags: ModuleProgramMssTagsSchema,
+  moduleSharingPolicy: ModuleSharingPolicySchema,
+  declaredProjections: z.array(ProjectionDescriptorSchema).default([]),
+  declaredAccessRequests: z.array(ModuleProgramAccessRequestSchema).default([]),
+  validation: ModuleProgramValidationMetadataSchema.optional(),
+  notes: z.array(z.string().min(1)).optional(),
+})
+export type ModuleProgramDescriptor = z.infer<typeof ModuleProgramDescriptorSchema>
+
+const ModuleProgramAdmissionRequirementKindSchema = z.enum([
+  'mss-tags',
+  'module-sharing-policy',
+  'projection-descriptor',
+  'provenance',
+  'validation-evidence',
+  'access-review',
+  'human-review',
+])
+
+export const ModuleProgramAdmissionRequirementSchema = createJsonObjectWithShapeSchema({
+  kind: ModuleProgramAdmissionRequirementKindSchema,
+  fields: z.array(z.string().min(1)).optional(),
+  projectionIds: z.array(z.string().min(1)).optional(),
+  accessKinds: z.array(z.string().min(1)).optional(),
+  message: z.string().min(1).optional(),
+})
+export type ModuleProgramAdmissionRequirement = z.infer<typeof ModuleProgramAdmissionRequirementSchema>
+
+const ModuleProgramAdmissionDiagnosticSeveritySchema = z.enum(['error', 'warning', 'info'])
+
+export const ModuleProgramAdmissionDiagnosticSchema = createJsonObjectWithShapeSchema({
+  severity: ModuleProgramAdmissionDiagnosticSeveritySchema,
+  code: z.string().min(1),
+  message: z.string().min(1),
+})
+export type ModuleProgramAdmissionDiagnostic = z.infer<typeof ModuleProgramAdmissionDiagnosticSchema>
+
+export const ModuleProgramAdmissionDecisionSchema = createJsonObjectWithShapeSchema({
+  decision: z.enum(['admitted', 'rejected', 'needs_review']),
+  reason: z.string().min(1),
+  requirements: z.array(ModuleProgramAdmissionRequirementSchema),
+  diagnostics: z.array(ModuleProgramAdmissionDiagnosticSchema),
+  descriptor: ModuleProgramDescriptorSchema.optional(),
+})
+export type ModuleProgramAdmissionDecision = z.infer<typeof ModuleProgramAdmissionDecisionSchema>
+
+type EvaluateModuleProgramAdmissionParams = {
+  descriptor: unknown
+}
+
+const formatValidationError = (error: z.ZodError): string =>
+  error.issues
+    .map((issue) => {
+      const path = issue.path.map((segment) => String(segment)).join('.') || '<root>'
+      return `${path}: ${issue.message}`
+    })
+    .join('; ')
+
+const toSortedUnique = (values: Iterable<string>) => [...new Set(values)].sort()
+
+const createAdmissionDecision = (
+  decision: z.input<typeof ModuleProgramAdmissionDecisionSchema>,
+): ModuleProgramAdmissionDecision => ModuleProgramAdmissionDecisionSchema.parse(decision)
+
+const createRejectedDecisionFromValidationError = (error: z.ZodError): ModuleProgramAdmissionDecision => {
+  const mssFields = toSortedUnique(
+    error.issues
+      .filter((issue) => issue.path[0] === 'mssTags' && typeof issue.path[1] === 'string')
+      .map((issue) => String(issue.path[1])),
+  )
+
+  if (mssFields.length > 0) {
+    return createAdmissionDecision({
+      decision: 'rejected',
+      reason: 'missing-required-mss-tags',
+      requirements: [
+        ModuleProgramAdmissionRequirementSchema.parse({
+          kind: 'mss-tags',
+          fields: mssFields,
+        }),
+      ],
+      diagnostics: [
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'error',
+          code: 'missing_mss_tags',
+          message: `Module program descriptor must include non-empty MSS tags: ${mssFields.join(', ')}.`,
+        }),
+      ],
+    })
+  }
+
+  const moduleSharingPolicyInvalid = error.issues.some((issue) => issue.path[0] === 'moduleSharingPolicy')
+  if (moduleSharingPolicyInvalid) {
+    return createAdmissionDecision({
+      decision: 'rejected',
+      reason: 'invalid-module-sharing-policy',
+      requirements: [
+        ModuleProgramAdmissionRequirementSchema.parse({
+          kind: 'module-sharing-policy',
+          fields: ['moduleSharingPolicy'],
+        }),
+      ],
+      diagnostics: [
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'error',
+          code: 'invalid_module_sharing_policy',
+          message: 'Module program descriptor must declare moduleSharingPolicy as all, none, or ask.',
+        }),
+      ],
+    })
+  }
+
+  return createAdmissionDecision({
+    decision: 'rejected',
+    reason: 'invalid-module-program-descriptor',
+    requirements: [
+      ModuleProgramAdmissionRequirementSchema.parse({
+        kind: 'human-review',
+        message: 'Fix schema validation errors before admission.',
+      }),
+    ],
+    diagnostics: [
+      ModuleProgramAdmissionDiagnosticSchema.parse({
+        severity: 'error',
+        code: 'invalid_descriptor',
+        message: formatValidationError(error),
+      }),
+    ],
+  })
+}
+
+const classifyDeclaredAccessRequest = ({
+  accessRequest,
+  reviewAccessKinds,
+  forbiddenAccessKinds,
+  diagnostics,
+}: {
+  accessRequest: ModuleProgramAccessRequest
+  reviewAccessKinds: Set<string>
+  forbiddenAccessKinds: Set<string>
+  diagnostics: ModuleProgramAdmissionDiagnostic[]
+}) => {
+  switch (accessRequest.kind) {
+    case 'module-projection-read':
+      return
+    case 'module-read':
+      reviewAccessKinds.add(accessRequest.kind)
+      diagnostics.push(
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'warning',
+          code: 'module_read_requires_projection_boundary',
+          message: 'Broad module-read declarations must be reviewed and narrowed to projection reads when possible.',
+        }),
+      )
+      return
+    case 'skill-use':
+      if (accessRequest.access !== 'read') {
+        reviewAccessKinds.add(accessRequest.kind)
+        diagnostics.push(
+          ModuleProgramAdmissionDiagnosticSchema.parse({
+            severity: 'warning',
+            code: 'skill_access_review_required',
+            message: 'Skill-use declarations must be read-only or reviewed before admission.',
+          }),
+        )
+      }
+      return
+    case 'cli-use':
+      if (accessRequest.access !== 'read' || !accessRequest.allowedPaths || accessRequest.allowedPaths.length === 0) {
+        reviewAccessKinds.add(accessRequest.kind)
+        diagnostics.push(
+          ModuleProgramAdmissionDiagnosticSchema.parse({
+            severity: 'warning',
+            code: 'cli_access_review_required',
+            message: 'CLI declarations must be read-only and path-bounded or they require review.',
+          }),
+        )
+      }
+      return
+    case 'inference-use':
+      reviewAccessKinds.add(accessRequest.kind)
+      diagnostics.push(
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'warning',
+          code: 'inference_access_review_required',
+          message: 'Inference-use declarations are metadata only and require later runtime policy review.',
+        }),
+      )
+      return
+    case 'self-spawn':
+      if (accessRequest.maxConcurrent === undefined || accessRequest.maxConcurrent > 8) {
+        reviewAccessKinds.add(accessRequest.kind)
+        diagnostics.push(
+          ModuleProgramAdmissionDiagnosticSchema.parse({
+            severity: 'warning',
+            code: 'self_spawn_bounds_required',
+            message: 'Self-spawn declarations must include bounded maxConcurrent limits.',
+          }),
+        )
+      }
+      return
+    case 'network-api-use':
+      if (accessRequest.scope !== 'bounded' || !accessRequest.allowedHosts || accessRequest.allowedHosts.length === 0) {
+        reviewAccessKinds.add(accessRequest.kind)
+        diagnostics.push(
+          ModuleProgramAdmissionDiagnosticSchema.parse({
+            severity: 'warning',
+            code: 'network_access_review_required',
+            message: 'Network/API declarations must be bounded and reviewed by a later grant policy path.',
+          }),
+        )
+      }
+      return
+    case 'external-service-reference':
+      reviewAccessKinds.add(accessRequest.kind)
+      diagnostics.push(
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'warning',
+          code: 'external_service_review_required',
+          message: 'External service declarations require policy review before runtime grants.',
+        }),
+      )
+      return
+    case 'process-execution':
+      forbiddenAccessKinds.add(accessRequest.kind)
+      diagnostics.push(
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'error',
+          code: 'process_execution_forbidden',
+          message: 'Module Program Admission Actor does not grant or run process execution.',
+        }),
+      )
+      return
+    default: {
+      const exhaustive: never = accessRequest
+      return exhaustive
+    }
+  }
+}
+
+export const evaluateModuleProgramAdmission = ({
+  descriptor,
+}: EvaluateModuleProgramAdmissionParams): ModuleProgramAdmissionDecision => {
+  const descriptorResult = ModuleProgramDescriptorSchema.safeParse(descriptor)
+  if (!descriptorResult.success) {
+    return createRejectedDecisionFromValidationError(descriptorResult.error)
+  }
+
+  const parsedDescriptor = descriptorResult.data
+  const sourceModuleId = parsedDescriptor.sourceModuleId ?? parsedDescriptor.programId
+
+  const mismatchedProjectionIds = parsedDescriptor.declaredProjections
+    .filter((projection) => projection.sourceModuleId !== sourceModuleId)
+    .map((projection) => projection.projectionId)
+
+  if (mismatchedProjectionIds.length > 0) {
+    return createAdmissionDecision({
+      decision: 'rejected',
+      reason: 'projection-source-module-mismatch',
+      requirements: [
+        ModuleProgramAdmissionRequirementSchema.parse({
+          kind: 'projection-descriptor',
+          projectionIds: mismatchedProjectionIds,
+          message: `Declared projection source module must match ${sourceModuleId}.`,
+        }),
+      ],
+      diagnostics: [
+        ModuleProgramAdmissionDiagnosticSchema.parse({
+          severity: 'error',
+          code: 'projection_source_module_mismatch',
+          message: `Projection descriptors must use sourceModuleId="${sourceModuleId}".`,
+        }),
+      ],
+      descriptor: parsedDescriptor,
+    })
+  }
+
+  const diagnostics: ModuleProgramAdmissionDiagnostic[] = []
+  const reviewAccessKinds = new Set<string>()
+  const forbiddenAccessKinds = new Set<string>()
+
+  for (const accessRequest of parsedDescriptor.declaredAccessRequests) {
+    classifyDeclaredAccessRequest({
+      accessRequest,
+      reviewAccessKinds,
+      forbiddenAccessKinds,
+      diagnostics,
+    })
+  }
+
+  if (forbiddenAccessKinds.size > 0) {
+    return createAdmissionDecision({
+      decision: 'rejected',
+      reason: 'forbidden-declared-access-request',
+      requirements: [
+        ModuleProgramAdmissionRequirementSchema.parse({
+          kind: 'access-review',
+          accessKinds: toSortedUnique(forbiddenAccessKinds),
+          message: 'Remove forbidden access declarations from this descriptor.',
+        }),
+      ],
+      diagnostics,
+      descriptor: parsedDescriptor,
+    })
+  }
+
+  if (reviewAccessKinds.size > 0) {
+    return createAdmissionDecision({
+      decision: 'needs_review',
+      reason: 'declared-access-review-required',
+      requirements: [
+        ModuleProgramAdmissionRequirementSchema.parse({
+          kind: 'access-review',
+          accessKinds: toSortedUnique(reviewAccessKinds),
+          message: 'Declared access requests require later runtime policy review.',
+        }),
+      ],
+      diagnostics,
+      descriptor: parsedDescriptor,
+    })
+  }
+
+  return createAdmissionDecision({
+    decision: 'admitted',
+    reason: 'module-program-descriptor-valid',
+    requirements: [],
+    diagnostics: [],
+    descriptor: parsedDescriptor,
+  })
+}
+
+export const moduleProgramAdmissionActorExtension = useExtension(MODULE_PROGRAM_ADMISSION_ACTOR_ID, ({ trigger }) => {
+  return {
+    [MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS.descriptor_evaluate](detail: unknown) {
+      const decision = evaluateModuleProgramAdmission({ descriptor: detail })
+      trigger({
+        type: MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS.decision,
+        detail: decision,
+      })
+    },
+  }
+})

--- a/src/modules/module-program-admission.ts
+++ b/src/modules/module-program-admission.ts
@@ -11,8 +11,21 @@ export const toModuleProgramAdmissionActorEventType = <TEvent extends string>(
   event: TEvent,
 ): `${typeof MODULE_PROGRAM_ADMISSION_ACTOR_ID}:${TEvent}` => `${MODULE_PROGRAM_ADMISSION_ACTOR_ID}:${event}`
 
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
 const createJsonObjectWithShapeSchema = <TShape extends z.ZodRawShape>(shape: TShape) =>
-  z.object(shape).catchall(JsonValueSchema)
+  z
+    .custom<Record<string, unknown>>((value) => isPlainRecord(value), {
+      message: 'Expected a plain JSON object.',
+    })
+    .pipe(z.object(shape).catchall(JsonValueSchema))
 
 const ModuleProgramAccessModeSchema = z.enum(['read', 'write', 'execute'])
 
@@ -105,7 +118,7 @@ const ProcessExecutionAccessRequestSchema = createJsonObjectWithShapeSchema({
   reason: z.string().min(1).optional(),
 })
 
-export const ModuleProgramAccessRequestSchema = z.discriminatedUnion('kind', [
+export const ModuleProgramAccessRequestSchema = z.union([
   ModuleProjectionReadAccessRequestSchema,
   ModuleReadAccessRequestSchema,
   SkillUseAccessRequestSchema,

--- a/src/modules/tests/module-program-admission.spec.ts
+++ b/src/modules/tests/module-program-admission.spec.ts
@@ -1,0 +1,545 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { behavioral, type SnapshotMessage, useInstaller } from '../../behavioral.ts'
+import { moduleProgramAdmissionActorExtension } from '../../modules.ts'
+import {
+  evaluateModuleProgramAdmission,
+  MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS,
+  ModuleProgramAdmissionDecisionSchema,
+  ModuleProgramDescriptorSchema,
+  toModuleProgramAdmissionActorEventType,
+} from '../module-program-admission.ts'
+import { ProjectionDescriptorSchema } from '../projection-boundary-actor.ts'
+
+type ObservedEvent = { type: string; detail?: unknown }
+type Harness = {
+  events: ObservedEvent[]
+  snapshots: SnapshotMessage[]
+  trigger: (event: { type: string; detail?: unknown }) => void
+}
+
+const descriptorEvaluateEventType = toModuleProgramAdmissionActorEventType(
+  MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS.descriptor_evaluate,
+)
+const decisionEventType = toModuleProgramAdmissionActorEventType(MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS.decision)
+
+const farmStandSupplierProjection = ProjectionDescriptorSchema.parse({
+  projectionId: 'farm-stand-supplier-v1',
+  sourceModuleId: 'farm-stand',
+  audience: {
+    kind: 'supplier-view',
+    id: 'supplier-network-1',
+  },
+  shape: {
+    fields: ['supplierSku', 'inventoryStatus', 'reorderThreshold'],
+    facts: ['stock-level'],
+    resources: ['purchase-orders'],
+  },
+  provenance: {
+    sourceId: 'farm-stand-owner-state',
+    sourceModuleId: 'farm-stand',
+    lineage: ['inventory-ledger', 'owner-console'],
+  },
+})
+
+const farmStandMarketOrganizerProjection = ProjectionDescriptorSchema.parse({
+  projectionId: 'farm-stand-market-organizer-v1',
+  sourceModuleId: 'farm-stand',
+  audience: {
+    kind: 'market-organizer-view',
+    id: 'organizer-1',
+  },
+  shape: {
+    fields: ['boothId', 'inspectionStatus', 'deliveryWindow'],
+    facts: ['compliance-attestation'],
+    resources: ['logistics-manifest'],
+  },
+  provenance: {
+    sourceId: 'farm-stand-owner-state',
+    sourceModuleId: 'farm-stand',
+    lineage: ['booth-compliance', 'market-logistics'],
+  },
+})
+
+const farmStandShopperProjection = ProjectionDescriptorSchema.parse({
+  projectionId: 'farm-stand-shopper-v1',
+  sourceModuleId: 'farm-stand',
+  audience: {
+    kind: 'shopper-view',
+  },
+  shape: {
+    fields: ['catalogTitle', 'availabilityBand'],
+    facts: ['public-stock-band'],
+    resources: ['catalog'],
+  },
+  provenance: {
+    sourceId: 'farm-stand-owner-state',
+    sourceModuleId: 'farm-stand',
+    lineage: ['catalog-export'],
+  },
+})
+
+const baseFarmStandDescriptor = ModuleProgramDescriptorSchema.parse({
+  programId: 'farm-stand',
+  name: 'Farm Stand',
+  version: '1.0.0',
+  source: {
+    kind: 'local-file',
+    path: 'src/modules/farm-stand.ts',
+    issue: 328,
+    commit: '0a4f1123',
+  },
+  provenance: {
+    createdBy: 'node-owner',
+    createdFromIssue: 328,
+    createdFromPrompt: 'Create a governed farm stand module program descriptor.',
+    reviewedBy: ['runtime-reviewer'],
+  },
+  mssTags: {
+    content: ['produce-catalog'],
+    structure: ['projection-descriptors'],
+    mechanics: ['admission-decision'],
+    boundary: ['projection-governed-sharing'],
+    scale: ['single-node-starter'],
+  },
+  moduleSharingPolicy: 'all',
+  declaredProjections: [farmStandSupplierProjection, farmStandMarketOrganizerProjection, farmStandShopperProjection],
+  declaredAccessRequests: [
+    {
+      kind: 'module-projection-read',
+      targetModuleId: 'inventory-hub',
+      projectionId: 'inventory-hub-supplier-v1',
+      reason: 'Needs supplier-facing inventory state.',
+    },
+  ],
+  validation: {
+    tests: ['src/modules/tests/module-program-admission.spec.ts'],
+    commands: ['bun test src/modules/tests/module-program-admission.spec.ts'],
+    notes: ['Future module proposal generators should emit this validation metadata.'],
+  },
+  notes: ['Farm Stand is an example source module program fixture only.'],
+})
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+
+const createDescriptor = () => clone(baseFarmStandDescriptor)
+
+const createHarness = (): Harness => {
+  const events: ObservedEvent[] = []
+  const snapshots: SnapshotMessage[] = []
+  const { addBThread, trigger, useFeedback, useSnapshot, reportSnapshot } = behavioral()
+  const install = useInstaller({
+    trigger,
+    useSnapshot,
+    reportSnapshot,
+    addBThread,
+    ttlMs: 1_000,
+  })
+
+  useFeedback(install(moduleProgramAdmissionActorExtension))
+  useFeedback({
+    [decisionEventType]: (detail: unknown) => {
+      events.push({ type: decisionEventType, detail })
+    },
+  })
+  useSnapshot((snapshot) => {
+    snapshots.push(snapshot)
+  })
+
+  return { events, snapshots, trigger }
+}
+
+const waitForDecisionEvent = async ({
+  harness,
+  after = 0,
+  timeoutMs = 3_000,
+}: {
+  harness: Harness
+  after?: number
+  timeoutMs?: number
+}) => {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt <= timeoutMs) {
+    const match = harness.events.slice(after).find((event) => event.type === decisionEventType)
+    if (match) {
+      return ModuleProgramAdmissionDecisionSchema.parse(match.detail)
+    }
+    await Bun.sleep(10)
+  }
+
+  throw new Error('Timed out waiting for module program admission decision event')
+}
+
+describe('module program admission actor', () => {
+  test('keeps a flat actor file and does not create a nested module-program-admission folder', async () => {
+    expect(await Bun.file('src/modules/module-program-admission.ts').exists()).toBe(true)
+    expect(existsSync('src/modules/module-program-admission')).toBe(false)
+  })
+
+  test('emits an admission decision through the flat actor extension surface', async () => {
+    const harness = createHarness()
+    harness.trigger({
+      type: descriptorEvaluateEventType,
+      detail: createDescriptor(),
+    })
+
+    const decision = await waitForDecisionEvent({ harness })
+    expect(decision.decision).toBe('admitted')
+    expect(decision.reason).toBe('module-program-descriptor-valid')
+  })
+
+  test('admits a valid module program descriptor', () => {
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.reason).toBe('module-program-descriptor-valid')
+    expect(decision.requirements).toEqual([])
+    expect(decision.diagnostics).toEqual([])
+  })
+
+  test('rejects descriptor missing a required MSS tag category', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    const mssTags = { ...(descriptor.mssTags as Record<string, unknown>) }
+    delete mssTags.boundary
+    descriptor.mssTags = mssTags
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('missing-required-mss-tags')
+    expect(decision.requirements[0]).toEqual(
+      expect.objectContaining({
+        kind: 'mss-tags',
+        fields: expect.arrayContaining(['boundary']),
+      }),
+    )
+  })
+
+  test('rejects descriptor with an empty required MSS tag category', () => {
+    const descriptor = createDescriptor()
+    descriptor.mssTags.scale = []
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('missing-required-mss-tags')
+    expect(decision.requirements[0]).toEqual(
+      expect.objectContaining({
+        kind: 'mss-tags',
+        fields: expect.arrayContaining(['scale']),
+      }),
+    )
+  })
+
+  test('rejects descriptor missing moduleSharingPolicy', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    delete descriptor.moduleSharingPolicy
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-sharing-policy')
+  })
+
+  test('rejects descriptor with invalid moduleSharingPolicy', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    descriptor.moduleSharingPolicy = 'invalid-policy'
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-sharing-policy')
+  })
+
+  test('preserves all sharing policy in admission output', () => {
+    const descriptor = createDescriptor()
+    descriptor.moduleSharingPolicy = 'all'
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.moduleSharingPolicy).toBe('all')
+  })
+
+  test('preserves none sharing policy in admission output', () => {
+    const descriptor = createDescriptor()
+    descriptor.moduleSharingPolicy = 'none'
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.moduleSharingPolicy).toBe('none')
+  })
+
+  test('preserves ask sharing policy in admission output', () => {
+    const descriptor = createDescriptor()
+    descriptor.moduleSharingPolicy = 'ask'
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.moduleSharingPolicy).toBe('ask')
+  })
+
+  test('declared supplier, market-organizer, and shopper projections are structurally valid and distinct', () => {
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.declaredProjections).toHaveLength(3)
+
+    const projectionIds = (decision.descriptor?.declaredProjections ?? []).map((projection) => projection.projectionId)
+    expect(new Set(projectionIds).size).toBe(3)
+  })
+
+  test('farm stand projection views share one source module program id and are not independent source modules', () => {
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+
+    const sourceModuleIds = new Set(
+      (decision.descriptor?.declaredProjections ?? []).map((projection) => projection.sourceModuleId),
+    )
+
+    expect(sourceModuleIds.size).toBe(1)
+    expect(Array.from(sourceModuleIds)[0]).toBe('farm-stand')
+    expect(decision.descriptor?.programId).toBe('farm-stand')
+  })
+
+  test('rejects descriptor when declared projection source module id mismatches descriptor source module id', () => {
+    const descriptor = createDescriptor()
+    const firstProjection = descriptor.declaredProjections[0]
+    expect(firstProjection).toBeDefined()
+    descriptor.declaredProjections[0] = {
+      ...firstProjection!,
+      sourceModuleId: 'other-source-module',
+    }
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('projection-source-module-mismatch')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'projection_source_module_mismatch',
+      }),
+    )
+  })
+
+  test('preserves module-projection-read access requests as data', () => {
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.declaredAccessRequests[0]).toEqual({
+      kind: 'module-projection-read',
+      targetModuleId: 'inventory-hub',
+      projectionId: 'inventory-hub-supplier-v1',
+      reason: 'Needs supplier-facing inventory state.',
+    })
+  })
+
+  test('broad unrestricted module state read declaration produces needs_review', () => {
+    const descriptor = createDescriptor()
+    descriptor.declaredAccessRequests = [
+      {
+        kind: 'module-read',
+        targetModuleId: 'farm-stand',
+        scope: 'unrestricted',
+        reason: 'Needs full access to farm stand state.',
+      },
+    ]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('needs_review')
+    expect(decision.reason).toBe('declared-access-review-required')
+    expect(decision.requirements[0]).toEqual(
+      expect.objectContaining({
+        kind: 'access-review',
+        accessKinds: ['module-read'],
+      }),
+    )
+  })
+
+  test('read-only skill-use declaration is preserved as data and does not invoke skills', () => {
+    const descriptor = createDescriptor()
+    descriptor.declaredAccessRequests = [
+      {
+        kind: 'skill-use',
+        skillName: 'plaited-context',
+        access: 'read',
+        reason: 'Needs source-grounded context assembly.',
+      },
+    ]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.declaredAccessRequests[0]).toEqual({
+      kind: 'skill-use',
+      skillName: 'plaited-context',
+      access: 'read',
+      reason: 'Needs source-grounded context assembly.',
+    })
+  })
+
+  test('read-only cli-use declaration is preserved as data and does not execute commands', () => {
+    const descriptor = createDescriptor()
+    descriptor.declaredAccessRequests = [
+      {
+        kind: 'cli-use',
+        command: 'rg',
+        access: 'read',
+        allowedPaths: ['src', 'skills', 'docs', 'AGENTS.md'],
+        reason: 'Needs read-only source search.',
+      },
+    ]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('admitted')
+    expect(decision.descriptor?.declaredAccessRequests[0]).toEqual({
+      kind: 'cli-use',
+      command: 'rg',
+      access: 'read',
+      allowedPaths: ['src', 'skills', 'docs', 'AGENTS.md'],
+      reason: 'Needs read-only source search.',
+    })
+  })
+
+  test('inference-use declaration is preserved as data and returns needs_review', () => {
+    const descriptor = createDescriptor()
+    descriptor.declaredAccessRequests = [
+      {
+        kind: 'inference-use',
+        modelRole: 'planner',
+        inputBoundary: 'retrieved-context',
+        outputBoundary: 'proposal-only',
+        reason: 'Generate plans from retrieved context.',
+      },
+    ]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('needs_review')
+    expect(decision.reason).toBe('declared-access-review-required')
+    expect(decision.descriptor?.declaredAccessRequests[0]).toEqual({
+      kind: 'inference-use',
+      modelRole: 'planner',
+      inputBoundary: 'retrieved-context',
+      outputBoundary: 'proposal-only',
+      reason: 'Generate plans from retrieved context.',
+    })
+  })
+
+  test('unbounded self-spawn declaration produces needs_review', () => {
+    const descriptor = createDescriptor()
+    descriptor.declaredAccessRequests = [
+      {
+        kind: 'self-spawn',
+        access: 'read',
+        reason: 'Parallel read-only planning over context.',
+      },
+    ]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('needs_review')
+    expect(decision.reason).toBe('declared-access-review-required')
+    expect(decision.requirements[0]).toEqual(
+      expect.objectContaining({
+        kind: 'access-review',
+        accessKinds: ['self-spawn'],
+      }),
+    )
+  })
+
+  test('rejects forbidden process execution access declarations', () => {
+    const descriptor = createDescriptor()
+    descriptor.declaredAccessRequests = [
+      {
+        kind: 'process-execution',
+        command: 'bun run dangerous',
+        reason: 'Execute commands directly.',
+      },
+    ]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('forbidden-declared-access-request')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'process_execution_forbidden',
+      }),
+    )
+  })
+
+  test('preserves source and provenance in admission output', () => {
+    const descriptor = createDescriptor()
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.descriptor?.source).toEqual(descriptor.source)
+    expect(decision.descriptor?.provenance).toEqual(descriptor.provenance)
+  })
+
+  test('decision output always includes decision, reason, requirements, and diagnostics', () => {
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+
+    expect(decision).toEqual(
+      expect.objectContaining({
+        decision: expect.any(String),
+        reason: expect.any(String),
+        requirements: expect.any(Array),
+        diagnostics: expect.any(Array),
+      }),
+    )
+  })
+
+  test('decisions and descriptors remain JSON-shaped and replay-safe', () => {
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+
+    const serialized = JSON.stringify(decision)
+    const reparsed = JSON.parse(serialized)
+
+    expect(reparsed).toEqual(decision)
+  })
+
+  test('invalid non-JSON descriptor data is rejected and diagnosed', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    const provenance = {
+      ...(descriptor.provenance as Record<string, unknown>),
+      invalidFn: () => 'non-json',
+    }
+    descriptor.provenance = provenance
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-program-descriptor')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_descriptor',
+      }),
+    )
+  })
+
+  test('admitted descriptor projection data remains compatible with projection boundary schemas', async () => {
+    expect(await Bun.file('src/modules/projection-boundary-actor.ts').exists()).toBe(true)
+
+    const decision = evaluateModuleProgramAdmission({ descriptor: createDescriptor() })
+    const parsedProjections = (decision.descriptor?.declaredProjections ?? []).map((projection) =>
+      ProjectionDescriptorSchema.parse(projection),
+    )
+    const [supplierProjection, marketOrganizerProjection, shopperProjection] = parsedProjections
+
+    expect(parsedProjections).toHaveLength(3)
+    expect(supplierProjection).toBeDefined()
+    expect(marketOrganizerProjection).toBeDefined()
+    expect(shopperProjection).toBeDefined()
+    expect(supplierProjection?.projectionId).toBe('farm-stand-supplier-v1')
+    expect(marketOrganizerProjection?.projectionId).toBe('farm-stand-market-organizer-v1')
+    expect(shopperProjection?.projectionId).toBe('farm-stand-shopper-v1')
+  })
+})

--- a/src/modules/tests/module-program-admission.spec.ts
+++ b/src/modules/tests/module-program-admission.spec.ts
@@ -6,6 +6,8 @@ import {
   evaluateModuleProgramAdmission,
   MODULE_PROGRAM_ADMISSION_ACTOR_EVENTS,
   ModuleProgramAdmissionDecisionSchema,
+  ModuleProgramAdmissionDiagnosticSchema,
+  ModuleProgramAdmissionRequirementSchema,
   ModuleProgramDescriptorSchema,
   toModuleProgramAdmissionActorEventType,
 } from '../module-program-admission.ts'
@@ -123,6 +125,25 @@ const baseFarmStandDescriptor = ModuleProgramDescriptorSchema.parse({
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
 const createDescriptor = () => clone(baseFarmStandDescriptor)
+
+class NonPlainSource {
+  readonly kind = 'local-file'
+  readonly path = 'src/modules/non-plain-source.ts'
+}
+
+class NonPlainProvenance {
+  readonly createdBy = 'class-instance'
+}
+
+class NonPlainAccessRequest {
+  readonly kind = 'module-projection-read'
+  readonly targetModuleId = 'inventory-hub'
+  readonly projectionId = 'inventory-hub-supplier-v1'
+}
+
+class NonPlainExtraValue {
+  readonly marker = 'non-plain-extra'
+}
 
 const createHarness = (): Harness => {
   const events: ObservedEvent[] = []
@@ -523,6 +544,91 @@ describe('module program admission actor', () => {
         code: 'invalid_descriptor',
       }),
     )
+  })
+
+  test('descriptor with Date provenance is rejected and diagnosed', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    descriptor.provenance = new Date('2026-04-20T00:00:00.000Z')
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-program-descriptor')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_descriptor',
+      }),
+    )
+  })
+
+  test('descriptor with class-instance provenance is rejected and diagnosed', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    descriptor.provenance = new NonPlainProvenance()
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-program-descriptor')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_descriptor',
+      }),
+    )
+  })
+
+  test('descriptor with class-instance source is rejected and diagnosed', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    descriptor.source = new NonPlainSource()
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-program-descriptor')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_descriptor',
+      }),
+    )
+  })
+
+  test('descriptor with class-instance declared access request is rejected and diagnosed', () => {
+    const descriptor = createDescriptor() as Record<string, unknown>
+    descriptor.declaredAccessRequests = [new NonPlainAccessRequest()]
+
+    const decision = evaluateModuleProgramAdmission({ descriptor })
+
+    expect(decision.decision).toBe('rejected')
+    expect(decision.reason).toBe('invalid-module-program-descriptor')
+    expect(decision.diagnostics[0]).toEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'invalid_descriptor',
+      }),
+    )
+  })
+
+  test('admission requirement schema rejects class-instance extra values', () => {
+    const parseResult = ModuleProgramAdmissionRequirementSchema.safeParse({
+      kind: 'access-review',
+      accessKinds: ['cli-use'],
+      extra: new NonPlainExtraValue(),
+    })
+
+    expect(parseResult.success).toBe(false)
+  })
+
+  test('admission diagnostic schema rejects class-instance extra values', () => {
+    const parseResult = ModuleProgramAdmissionDiagnosticSchema.safeParse({
+      severity: 'warning',
+      code: 'access_review_required',
+      message: 'Needs review.',
+      extra: new NonPlainExtraValue(),
+    })
+
+    expect(parseResult.success).toBe(false)
   })
 
   test('admitted descriptor projection data remains compatible with projection boundary schemas', async () => {


### PR DESCRIPTION
## Context

- Add a flat core runtime Module Program Admission Actor under `src/modules/`.
- Establish a schema-backed admission contract for module program descriptors with
  `admitted | rejected | needs_review` decisions.
- Clarify vocabulary boundaries in skills so future prompts distinguish core runtime
  actors, module programs, projection views, and declared access asks.
- Fixes #328.

## Summary

- Added `src/modules/module-program-admission.ts`.
- Added descriptor, decision, requirement, and diagnostic schemas.
- Implemented `evaluateModuleProgramAdmission` and `moduleProgramAdmissionActorExtension`.
- Reused projection/share vocabulary via `ProjectionDescriptorSchema` and
  `ModuleSharingPolicySchema` from `projection-boundary-actor.ts`.
- Added focused tests in `src/modules/tests/module-program-admission.spec.ts` for the
  required admission matrix and projection-boundary compatibility evidence.
- Exported the actor through `src/modules.ts`.
- Updated wording in:
  - `skills/plaited-runtime/SKILL.md`
  - `skills/mss-module-review/SKILL.md`
  - `.agents/skills/plaited-development/SKILL.md`

## Changed Files

- `src/modules/module-program-admission.ts`
- `src/modules/tests/module-program-admission.spec.ts`
- `src/modules.ts`
- `skills/plaited-runtime/SKILL.md`
- `skills/mss-module-review/SKILL.md`
- `.agents/skills/plaited-development/SKILL.md`

## Validation

- Targeted tests:
  - `bun test src/modules/tests/module-program-admission.spec.ts`
  - `bun test src/modules/tests/projection-boundary-actor.spec.ts`
- `bun --bun tsc --noEmit`: pass
- Additional required checks:
  - `bun bin/plaited.ts skills-validate '{"skillPath":"skills/plaited-runtime/SKILL.md"}'`
  - `bun bin/plaited.ts skills-validate '{"skillPath":"skills/mss-module-review/SKILL.md"}'`
  - `bun bin/plaited.ts skills-links '{"rootDir":".","path":"skills/plaited-runtime"}'`
  - `bun bin/plaited.ts skills-links '{"rootDir":".","path":"skills/mss-module-review"}'`
  - `bun skills/plaited-context/scripts/module-patterns.ts '{"files":["src/modules/module-program-admission.ts"]}'`
  - `bun skills/plaited-context/scripts/module-flow.ts '{"files":["src/modules/module-program-admission.ts"],"format":"json"}'`
  - `bun skills/plaited-context/scripts/module-flow.ts '{"files":["src/modules/module-program-admission.ts"],"format":"mermaid"}'`
  - `bun skills/plaited-context/scripts/git-context.ts '{"base":"origin/dev","paths":["src/modules/module-program-admission.ts","src/modules/tests","src/modules.ts","skills/plaited-runtime","skills/mss-module-review",".agents/skills/plaited-development"],"includeWorktrees":true}'`
  - `bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/module-program-admission.ts","operations":[{"type":"symbols"}]}'`
  - `bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/module-program-admission.ts","operations":[{"type":"references","line":473,"character":23}]}'`
  - `bun skills/typescript-lsp/scripts/run.ts '{"file":"src/modules/module-program-admission.ts","operations":[{"type":"definition","line":473,"character":23}]}'`

## Known Failures / Drift

- None observed in the scoped validation surface.

## Review Notes / Residual Risks

- Access classification is intentionally conservative for undelegated power surfaces
  (`inference-use`, broad `module-read`, unbounded `self-spawn`, broad network access).
- `module-flow` remains AST-local and sparse for helper/trigger edges in this actor;
  TypeScript LSP probes are included for symbol identity evidence.

## Agent Workflow Checklist

- [x] Used repo-local `plaited-development` skill when agent-authored
- [x] Targeted Bun tests listed or skipped with rationale
- [x] `bun --bun tsc --noEmit` run or skipped with rationale
- [x] Known `tsc` drift classified, if applicable
- [x] Unrelated untracked files left untouched
- [x] No broad refactor mixed into feature/fix slice
- [x] No installer/core contract weakened to pass tests
